### PR TITLE
update broken anchor href

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -20,7 +20,7 @@ export default () => (
           <img src="https://pbs.twimg.com/profile_images/430383711448625153/P4yD2jvY_400x400.jpeg" alt="" className="avatar"/>
           <h3>Scott Tolinski</h3>
           <a target="_blank" href="https://twitter.com/stolinski" className="person__social person__social--twitter">@stolinski</a>
-          <p>Web Developer, Creator of <a href="https://leveluptutorials.com/">Level Up Tuts</a>, Bboy, Robotops Crew and <a target="_blank" href="https://www.youtube.com/c/leveluptuts">Youtuber</a></p>
+          <p>Web Developer, Creator of <a href="https://leveluptuts.com/">Level Up Tuts</a>, Bboy, Robotops Crew and <a target="_blank" href="https://www.youtube.com/c/leveluptuts">Youtuber</a></p>
         </div>
       </div>
 


### PR DESCRIPTION
The Level Up Tutorials domain situation was a little confusing...

https://leveluptutorials.com does not resolve.
http://leveluptuts.com redirects to an incorrect site.
https://leveluptuts.com has an invalid SSL but loads the right site.

Anyway, just trying to nudge things in the right direction.