### PR TITLE
OSX tabbing link broken

### DIFF
--- a/shows/011 - Productivity Hot Tips.md
+++ b/shows/011 - Productivity Hot Tips.md
@@ -58,7 +58,7 @@ Sorry windows users.
 * Add Shift to select those itesm
 * `⌘+option+Arrow` to switch tabs
 * `⌘ + Number` to go to that tab #
-* [Enable tabbing on OSX dialog Boxes](wesbos.com/osx-dialog-boxes-keyboard-tab/)
+* [Enable tabbing on OSX dialog Boxes](http://wesbos.com/osx-dialog-boxes-keyboard-tab/)
 * Press question mark in any google app to get a list of shortcuts
 
 ## Sick Picks


### PR DESCRIPTION
Link was missing `http://`, so it was appending it to the show's page url.