### PR TITLE
removed max-height and overflow scroll from _show.styl

### DIFF
--- a/styles/_show.styl
+++ b/styles/_show.styl
@@ -66,8 +66,6 @@
   padding 2rem
   width 62%
   font-size 1.5rem
-  max-height 800px
-  overflow scroll
   @media (max-width: 650px)
     width 100%
   .button


### PR DESCRIPTION
Removed max-height and overflow scroll from _show.styl, which will fix [issue 32](https://github.com/wesbos/Syntax/issues/32)