### PR TITLE
Adding localStorage to last played points on podcasts

### DIFF
--- a/components/Player.js
+++ b/components/Player.js
@@ -3,13 +3,13 @@ import Show from './Show';
 import formatTime from '../lib/formatTime';
 
 export default class Player extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       progressTime: 50,
       playing: false,
       duration: 0,
-      currentTime: 0,
+      currentTime: this.props.time,
       playbackRate: 1
     }
   }
@@ -30,10 +30,12 @@ export default class Player extends React.Component {
 
   scrub = (e) => {
     const scrubTime = (e.nativeEvent.offsetX / this.progress.offsetWidth) * this.audio.duration;
+    localStorage.setItem('lastPlayed', JSON.stringify({podcast: this.props.show.displayNumber, lastPlayed: scrubTime}))
     this.audio.currentTime = scrubTime;
   }
 
   onPlayPause = (e) => {
+    // localStorage.setItem('lastPlayed', JSON.stringify({podcast: this.props.show.displayNumber, lastPlayed: this.state.currentTime}))
     this.setState({ playing: !this.audio.paused });
     const method = this.audio.paused ? 'add' : 'remove';
     document.querySelector('.bars').classList[method]('bars--paused'); // 💩
@@ -56,12 +58,25 @@ export default class Player extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    localStorage.setItem('lastPlayed', JSON.stringify({podcast: this.props.show.displayNumber, lastPlayed: this.state.currentTime}))
     if(this.props.show.number !== prevProps.show.number) {
+      this.audio.currentTime = this.state.currentTime
       this.audio.play();
     }
   }
 
+  componentDidMount() {
+    console.log('mounted player');
+    if(!localStorage.lastPlayed) return
+      const data = JSON.parse(localStorage.getItem('lastPlayed'))
+      this.setState({
+        currentTime: data.lastPlayed
+      })
+      console.log(this.state);
+  }
+
   render() {
+    console.log('player being rendered! ' + this.state.currentTime)
     const { show } = this.props;
     const { playing, progressTime, currentTime, duration } = this.state;
     return (

--- a/components/Player.js
+++ b/components/Player.js
@@ -9,8 +9,8 @@ export default class Player extends React.Component {
     var lastPlayed = 0;
 
     if (typeof window !== 'undefined') {
-     const lp = localStorage.getItem('lastPlayed' + this.props.show.number);
-     if(lp) lastPlayed = JSON.parse(lp).lastPlayed;
+      const lp = localStorage.getItem('lastPlayed' + this.props.show.number);
+      if(lp) lastPlayed = JSON.parse(lp).lastPlayed;
     }
 
     this.state = {
@@ -51,7 +51,6 @@ export default class Player extends React.Component {
 
   scrub = (e) => {
     const scrubTime = (e.nativeEvent.offsetX / this.progress.offsetWidth) * this.audio.duration;
-    //localStorage.setItem('lastPlayed', JSON.stringify({podcast: this.props.show.displayNumber, lastPlayed: scrubTime}))
     this.audio.currentTime = scrubTime;
   }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,7 +10,7 @@ import Page from '../components/Page';
 
 export default class IndexPage extends React.Component {
   constructor(props) {
-    super(props);
+    super();
     const currentShow = props.url.query.number || props.shows[0].displayNumber;
 
     this.state = {
@@ -39,7 +39,6 @@ export default class IndexPage extends React.Component {
   };
 
   render() {
-    console.log('main render being called!!');
     const { shows = [], baseURL } = this.props;
     const { currentShow, currentPlaying } = this.state;
     // Currently Shown shownotes

--- a/pages/index.js
+++ b/pages/index.js
@@ -13,17 +13,9 @@ export default class IndexPage extends React.Component {
     super(props);
     const currentShow = props.url.query.number || props.shows[0].displayNumber;
 
-    var lastPlayed = 0;
-
-    if (typeof window !== 'undefined') {
-     const lp = localStorage.getItem('lastPlayed' + parseInt(currentShow));
-     if(lp) lastPlayed = JSON.parse(lp).lastPlayed;
-    }
-
     this.state = {
       currentShow,
-      currentPlaying: currentShow,
-      currentTime: lastPlayed
+      currentPlaying: currentShow
     };
   }
 
@@ -59,7 +51,7 @@ export default class IndexPage extends React.Component {
         <Meta show={show} baseURL={baseURL} />
         <div className="wrapper">
           <div className="show-wrap">
-            <Player show={current} time={this.state.currentTime}/>
+            <Player show={current} />
             <ShowList
               shows={shows}
               currentShow={currentShow}

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,13 +10,20 @@ import Page from '../components/Page';
 
 export default class IndexPage extends React.Component {
   constructor(props) {
-    super();
+    super(props);
     const currentShow = props.url.query.number || props.shows[0].displayNumber;
+
+    var lastPlayed = 0;
+
+    if (typeof window !== 'undefined') {
+     const lp = localStorage.getItem('lastPlayed' + parseInt(currentShow));
+     if(lp) lastPlayed = JSON.parse(lp).lastPlayed;
+    }
 
     this.state = {
       currentShow,
       currentPlaying: currentShow,
-      currentTime: 0
+      currentTime: lastPlayed
     };
   }
 
@@ -32,16 +39,6 @@ export default class IndexPage extends React.Component {
     if (query.number) {
       this.setState({ currentShow: query.number });
     }
-  }
-
-  componentDidMount() {
-    console.log('mounted main!');
-    if(!localStorage.lastPlayed) return
-      const {podcast, lastPlayed} = JSON.parse(localStorage.getItem('lastPlayed'))
-      this.setState({
-        currentPlaying: podcast,
-        currentShow: podcast
-      })
   }
 
   setCurrentPlaying = currentPlaying => {

--- a/pages/index.js
+++ b/pages/index.js
@@ -16,6 +16,7 @@ export default class IndexPage extends React.Component {
     this.state = {
       currentShow,
       currentPlaying: currentShow,
+      currentTime: 0
     };
   }
 
@@ -33,12 +34,23 @@ export default class IndexPage extends React.Component {
     }
   }
 
+  componentDidMount() {
+    console.log('mounted main!');
+    if(!localStorage.lastPlayed) return
+      const {podcast, lastPlayed} = JSON.parse(localStorage.getItem('lastPlayed'))
+      this.setState({
+        currentPlaying: podcast,
+        currentShow: podcast
+      })
+  }
+
   setCurrentPlaying = currentPlaying => {
     console.log('Setting current playing');
     this.setState({ currentPlaying });
   };
 
   render() {
+    console.log('main render being called!!');
     const { shows = [], baseURL } = this.props;
     const { currentShow, currentPlaying } = this.state;
     // Currently Shown shownotes
@@ -50,7 +62,7 @@ export default class IndexPage extends React.Component {
         <Meta show={show} baseURL={baseURL} />
         <div className="wrapper">
           <div className="show-wrap">
-            <Player show={current} />
+            <Player show={current} time={this.state.currentTime}/>
             <ShowList
               shows={shows}
               currentShow={currentShow}


### PR DESCRIPTION
This solves issue [#42](https://github.com/wesbos/Syntax/issues/42).

As Next.js renders React components on the server-side, I had to use `if (typeof window !== 'undefined') {
` to have access to the `window` object. Functionality works as expected, however the console prompts a `React attempted to reuse markup in a container but the checksum was invalid.` upon initial page load which I am unsure on how to fix.

Big thanks to @ollie1700 for helping with this PR.

I hope this helps! 🔥

