### PR TITLE
Fixed floating Play/Bars buttons in ShowList

### DIFF
--- a/styles/_show.styl
+++ b/styles/_show.styl
@@ -10,6 +10,7 @@
     padding 10px
   &__playcontrols
     display flex
+    flex-shrink 0
     align-items center
     justify-content center
     width 5rem


### PR DESCRIPTION
Hi,
There is some kind of "float" playcontrols in ShowList component. When text content in Show item is really flexible, I don't think playcontrols should also being shrinked or growed.