### PR TITLE
Corrected link for Jest

### DIFF
--- a/shows/040 - Testing.md
+++ b/shows/040 - Testing.md
@@ -60,7 +60,7 @@ Developers, software engineers, designers, and web performance professionals flo
 33:00
 
 * Test Runners vs Assertion Libraries
-* [Jest](https://mochajs.org/)
+* [Jest](https://facebook.github.io/jest/)
 * [Mocha](https://mochajs.org/)
 * [Cucumber](https://cucumber.io/)
 * BBD (Big Black Dog)


### PR DESCRIPTION
The link for Jest is currently the same as Mocha (copy and paste?) so I've corrected it.