### PR TITLE
Changed formatting of show timestamp to display correct day of the month

### DIFF
--- a/lib/getShows.js
+++ b/lib/getShows.js
@@ -23,7 +23,7 @@ const loadShows = async () => {
     .map((show, i) => Object.assign({}, show.meta, {
       html: show.html,
       notesFile: files[i],
-      displayDate: format(parseFloat(show.meta.date), 'MMM Do, YYYY'),
+      displayDate: format(parseFloat(show.meta.date), 'MMM do, YYYY'),
       number: parseFloat(show.meta.number.toString(8)) // lol
     })) // flatten
     .map(show => Object.assign({}, show, { displayNumber: pad(show.number) })) // pad zeros


### PR DESCRIPTION
On the Syntax.fm site I was seeing the day of the month displayed incorrectly. For example, Ep. 052 was showing Jun 178th, 2018. I'm like 80% sure that this date doesn't exist.

Docs for date-fns seems to be incorrect (or maybe a bug on their part?) in regards to the formatting of days of the month (https://date-fns.org/v1.29.0/docs/format). This change fixed it for me to show the correct day of the month. Their own tests (https://github.com/date-fns/date-fns/blob/master/src/format/test.js#L54) use this format.

Ran it through all the existing shows and the dates seem to match up with iTunes dates (a few are off, but maybe the timestamps it the markdown files aren't in sync when they are actually published).