### PR TITLE
Fixes #128, add focus to volume UI

### DIFF
--- a/styles/_player.styl
+++ b/styles/_player.styl
@@ -1,5 +1,5 @@
 // accessible way of hiding inputs and labels
-.sr-only 
+.sr-only
   border 0 !important
   clip rect(1px, 1px, 1px, 1px) !important
   clip-path inset(50%) !important
@@ -97,6 +97,8 @@
     padding 1rem
     flex-wrap wrap
     flex 1 0 auto
+    &:focus-within
+      outline: -webkit-focus-ring-color auto 5px;
     &:hover
       label
         border-top 1px solid yellow


### PR DESCRIPTION
Fixes #128 Used focus-within pseudo class on player volume section to show outline ring when focusing on volume labels.
Also added keyboard shortcuts to control volume and other things in PR #130 .
