### PR TITLE
Fixed numbers in formatTime

### DIFF
--- a/lib/formatTime.js
+++ b/lib/formatTime.js
@@ -1,8 +1,8 @@
 export default function formatTime(time) {
     // Hours, minutes and seconds
-    var hrs = (~~(time / 3600)).toFixed(0);
-    var mins = (~~((time % 3600) / 60)).toFixed(0);
-    var secs = (time % 60).toFixed(0);
+    var hrs = Math.floor((~~(time / 3600)));
+    var mins = Math.floor((~~((time % 3600) / 60)));
+    var secs = Math.floor((time % 60));
 
     // Output like "1:01" or "4:03:59" or "123:03:59"
     var ret = "";


### PR DESCRIPTION
Fixed bug when timer shows ****:60** seconds
![image](https://user-images.githubusercontent.com/22624868/44466665-82047400-a629-11e8-8cd1-25351f9852c9.png)
