### PR TITLE
Update url prop to withRouter.

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,3 +1,4 @@
+import { withRouter } from "next/router";
 import React from 'react';
 import axios from 'axios';
 import ShowList from '../components/ShowList';
@@ -8,10 +9,10 @@ import Header from '../components/Header';
 import Footer from '../components/Footer';
 import Page from '../components/Page';
 
-export default class IndexPage extends React.Component {
+export default withRouter(class IndexPage extends React.Component {
   constructor(props) {
     super();
-    const currentShow = props.url.query.number || props.shows[0].displayNumber;
+    const currentShow = props.router.query.number || props.shows[0].displayNumber;
 
     this.state = {
       currentShow,
@@ -27,7 +28,7 @@ export default class IndexPage extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { pathname, query } = nextProps.url;
+    const { pathname, query } = nextProps.router;
     if (query.number) {
       this.setState({ currentShow: query.number });
     }
@@ -63,4 +64,4 @@ export default class IndexPage extends React.Component {
       </Page>
     );
   }
-}
+});


### PR DESCRIPTION
While pulling down the repo and working locally, I noticed this js error in the console:
```
Warning: the 'url' property is deprecated. https://err.sh/next.js/url-deprecated
```
This doesn't happen in production, so prob not a big deal.

This is just a simple fix for that error for local dev. I followed this codemod as instructed:
https://github.com/zeit/next-codemod#url-to-withrouter.

Love the podcast! ✌️ This is part of my Hacktoberfest, so hoping that this gets merged.