### PR TITLE
Increased font size and tweaked layout in header bios

### DIFF
--- a/styles/_person.styl
+++ b/styles/_person.styl
@@ -3,7 +3,7 @@
   justify-content space-between
   margin 1rem 0
   flex-wrap wrap
-
+  font-size 1.4rem
 
 .person
   background rgba(255,255,255,0.07)
@@ -14,9 +14,13 @@
     margin-bottom 1rem
   p
     margin-bottom 0
+    clear left
   h3
     margin 0
+    margin-top 10px
     font-size 2rem
+    @media (max-width: 800px)
+      margin-top 0
     em
       font-size 1rem
 
@@ -25,6 +29,7 @@
   width 80px
   float left
   margin-right 20px
+  margin-bottom 15px
   border 3px solid white
   box-shadow inset 0 0 10px red
   @media (max-width: 800px)


### PR DESCRIPTION
Hey guys, love the show. I was looking for a way to contribute to syntax.fm and felt the font size in the header bios way a bit too small to be easily readable.

On desktop, increasing the font size caused the bio to wrap around the avatar in a not-very-nice way, so I made some minor tweaks to account for this too. Hope it's a useful (if small) addition.

### Before:
![image](https://user-images.githubusercontent.com/41474928/46908665-071b5380-cf1e-11e8-9a83-4b78568e95cf.png)

### After:
![image](https://user-images.githubusercontent.com/41474928/46908667-113d5200-cf1e-11e8-88d7-d7824a9f7b89.png)
