### PR TITLE
sponsor.js: camel case two attributes for React

### DIFF
--- a/pages/sponsor.js
+++ b/pages/sponsor.js
@@ -67,10 +67,10 @@ export default class SponsorPage extends React.Component {
             downloads, and some of the shows reach 40-50,000 downloads just months after being launched.
           </p>
 
-          <blockquote class="twitter-tweet">
+          <blockquote className="twitter-tweet">
             <p lang="en" dir="ltr">To be honest <a href="https://twitter.com/syntaxfm?ref_src=twsrc%5Etfw">@syntaxfm</a> is the only podcast where I listen to the sponsor adds, they don’t event feel like adds</p>&mdash; Omar Aguinaga (@Soyoag) <a href="https://twitter.com/Soyoag/status/988205788794572800?ref_src=twsrc%5Etfw">April 22, 2018</a>
-          </blockquote> 
-          <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 
+          </blockquote>
+          <script async src="https://platform.twitter.com/widgets.js" charSet="utf-8"></script>
 
           <p>
             While exact numbers are hard to get, here are a few nuggets of information about our audience that should
@@ -128,7 +128,7 @@ export default class SponsorPage extends React.Component {
           <p>We have found that we get the best results for our advertisers when they sponsor at least three shows.</p>
           <p>
             Currently each sponsor spot is $1,000 USD per episode with a minimum of three episodes, though this price will
-            increase as our audience does. Single show sponsorships are $1,200. 
+            increase as our audience does. Single show sponsorships are $1,200.
           </p>
 
           <p>As part of the sponsorship package, you'll get:</p>


### PR DESCRIPTION
This suppresses a couple "Invalid DOM property" warnings