### PR TITLE
Fix outline colors on subscribe links and volume div for accessibility

### DIFF
--- a/styles/_player.styl
+++ b/styles/_player.styl
@@ -114,7 +114,7 @@
     flex-wrap wrap
     flex 1 0 auto
     &:focus-within
-      outline: -webkit-focus-ring-color auto 5px;
+      outline: yellow auto 5px;
     &:hover
       label
         border-top 1px solid yellow

--- a/styles/_subscribe.styl
+++ b/styles/_subscribe.styl
@@ -1,0 +1,3 @@
+.subscribe__link a
+  &:focus
+    outline-color yellow

--- a/styles/style.styl
+++ b/styles/style.styl
@@ -11,3 +11,4 @@
 @import '_show.styl'
 @import '_button.styl'
 @import '_sponsor.styl'
+@import '_subscribe.styl'


### PR DESCRIPTION
Subscribe links outline color on focus was set to black, which was invisible against the black background. Updated to theme yellow.

Also, volume div was set to the webkit default blue while its sibling elements were set to the theme yellow. Updated to theme yellow.

This is a resubmission of PR #210 

@416serg 