### PR TITLE
Remove horizontal scroll bar on show listings

### DIFF
--- a/styles/_show.styl
+++ b/styles/_show.styl
@@ -66,7 +66,8 @@
   @media (max-width: 650px)
     height 300px
     width 100%
-    overflow-x scroll
+    overflow-x auto
+    overflow-y scroll
 
 .showNotes
   padding 2rem


### PR DESCRIPTION
Fixes issue https://github.com/wesbos/Syntax/issues/215.

Makes overflow rules more verbose and sets overflow-x to auto so the horizontal scrollbar only appears if it's needed just in case.

I didn't include changes to package-lock.json in the commit, I hope that's ok?