### PR TITLE
Persist playbackRate and volume property

### DIFF
--- a/components/Player.js
+++ b/components/Player.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FaPlay, FaPause } from 'react-icons/fa';
 import formatTime from '../lib/formatTime';
+import VolumeBars from './VolumeBars';
 
 // TODO Fix all eslint issues
 
@@ -16,15 +17,6 @@ export default class Player extends React.Component {
     let lastPlayed = 0;
     let lastVolumePref = 0;
 
-    // for SSR
-    // if (typeof window !== 'undefined') {
-    //   const { show } = this.props;
-    //   const lp = localStorage.getItem(`lastPlayed${show.number}`);
-
-    //   // eslint-disable-next-line
-    //   if (lp) lastPlayed = JSON.parse(lp).lastPlayed;
-    // }
-
     // for Server Side Rendering
     if (typeof window !== 'undefined') {
       const { show } = this.props;
@@ -33,7 +25,6 @@ export default class Player extends React.Component {
         `lastVolumeSetting${show.number}`
       );
 
-      // eslint-disable-next-line
       if (lp) lastPlayed = JSON.parse(lp).lastPlayed;
       if (lastVolume) lastVolumePref = JSON.parse(lastVolume).lastVolumePref;
     }
@@ -57,39 +48,6 @@ export default class Player extends React.Component {
     this.audio.playbackRate = nextState.playbackRate;
   }
 
-  // componentDidUpdate(prevProps, prevState) {
-  //   const { show } = this.props;
-  //   const { currentTime, currentVolume } = this.state;
-  //   if (show.number !== prevProps.show.number) {
-  //     const lp = localStorage.getItem(`lastPlayed${show.number}`);
-  //     // const lastVolume = localStorage.getItem(
-  //     //   `lastVolumeSetting${show.number}`
-  //     // );
-  //     if (lp) {
-  //       const data = JSON.parse(lp);
-  //       // const data2 = JSON.parse(lastVolume);
-  //       // eslint-disable-next-line
-
-  //       this.setState({
-  //         currentTime: data.lastPlayed,
-  //         currentVolume: data2.currentVolume
-  //       });
-  //       this.audio.currentTime = data.lastPlayed;
-  //       // this.audio.volume = data2.currentVolume;
-  //     }
-  //     this.audio.play();
-  //   } else {
-  //     localStorage.setItem(
-  //       `lastPlayed${show.number}`,
-  //       JSON.stringify({ lastPlayed: currentTime })
-  //     );
-  //     // localStorage.setItem(
-  //     //   `lastVolumeSetting${show.number}`,
-  //     //   JSON.stringify({ currentVolume: currentVolume })
-  //     // );
-  //   }
-  // }
-
   componentDidUpdate(prevProps, prevState) {
     const { show } = this.props;
     const { currentTime, currentVolume } = this.state;
@@ -101,7 +59,6 @@ export default class Player extends React.Component {
       if (lp) {
         const data = JSON.parse(lp);
         const data2 = JSON.parse(lastVolume);
-        // eslint-disable-next-line
 
         this.setState({
           currentTime: data.lastPlayed,
@@ -123,32 +80,6 @@ export default class Player extends React.Component {
     }
   }
 
-  // timeUpdate = e => {
-  //   console.log('Updating Time');
-  //   const { show } = this.props;
-  //   const { timeWasLoaded } = this.state;
-  //   console.log(`🌈 ${timeWasLoaded}`);
-  //   // Check if the user already had a curent time
-  //   if (timeWasLoaded) {
-  //     const lp = localStorage.getItem(`lastPlayed${show.number}`);
-  //     const lastVolume = localStorage.getItem(
-  //       `lastVolumeSetting${show.number}`
-  //     );
-  //     if (lp) {
-  //       console.log(`💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎 ${lp}`);
-  //       console.log(`🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖 ${lastVolume}`);
-  //       e.currentTarget.currentTime = JSON.parse(lp).lastPlayed;
-  //       e.currentTarget.volume = JSON.parse(lastVolume).currentVolume;
-  //     }
-  //     this.setState({ timeWasLoaded: false });
-  //   } else {
-  //     const { currentTime = 0, duration = 0 } = e.currentTarget;
-
-  //     const progressTime = (currentTime / duration) * 100;
-  //     if (Number.isNaN(progressTime)) return;
-  //     this.setState({ progressTime, currentTime, duration });
-  //   }
-  // };
   timeUpdate = e => {
     console.log('Updating Time');
     const { show } = this.props;
@@ -179,7 +110,6 @@ export default class Player extends React.Component {
     console.log(`🌈🌈 ${timeWasLoaded}`);
     // Check if the user already had a curent volume
     if (timeWasLoaded) {
-      // const lp = localStorage.getItem(`lastPlayed${show.number}`);
       const lastVolume = localStorage.getItem(
         `lastVolumeSetting${show.number}`
       );
@@ -242,7 +172,7 @@ export default class Player extends React.Component {
   speed = change => {
     const playbackRateMax = 2.5;
     const playbackRateMin = 0.75;
-    // eslint-disable-next-line
+
     let playbackRate = this.state.playbackRate + change;
 
     if (playbackRate > playbackRateMax) {
@@ -286,7 +216,6 @@ export default class Player extends React.Component {
         </div>
 
         <div className="player__section player__section--middle">
-          {/* eslint-disable */}
           <div
             className="progress"
             onClick={this.scrub}
@@ -299,7 +228,6 @@ export default class Player extends React.Component {
             }}
             ref={x => (this.progress = x)}
           >
-            {/* eslint-enable */}
             <div
               className="progress__time"
               style={{ width: `${progressTime}%` }}
@@ -333,141 +261,11 @@ export default class Player extends React.Component {
           <div className="player__volume">
             <p>LOUDNESS</p>
             <div className="player__inputs">
-              <input
-                onChange={this.volume}
-                type="radio"
-                name="volume"
-                value="0.1"
-                id="vol10"
-                className="sr-only"
-                checked={this.checked}
-              />
-              <label htmlFor="vol10">
-                {/* eslint-disable-line */}
-                <span className="sr-only">Volume Level 10/100</span>
-              </label>
-              <input
-                onChange={this.volume}
-                type="radio"
-                name="volume"
-                value="0.2"
-                id="vol20"
-                className="sr-only"
-                checked={this.checked}
-              />
-              <label htmlFor="vol20">
-                {/* eslint-disable-line */}
-                <span className="sr-only">Volume Level 20/100</span>
-              </label>
-              <input
-                onChange={this.volume}
-                type="radio"
-                name="volume"
-                value="0.3"
-                id="vol30"
-                className="sr-only"
-                checked={this.checked}
-              />
-              <label htmlFor="vol30">
-                {/* eslint-disable-line */}
-                <span className="sr-only">Volume Level 30/100</span>
-              </label>
-              <input
-                onChange={this.volume}
-                type="radio"
-                name="volume"
-                value="0.4"
-                id="vol40"
-                className="sr-only"
-                checked={this.checked}
-              />
-              <label htmlFor="vol40">
-                {/* eslint-disable-line */}
-                <span className="sr-only">Volume Level 40/100</span>
-              </label>
-              <input
-                onChange={this.volume}
-                type="radio"
-                name="volume"
-                value="0.5"
-                id="vol50"
-                className="sr-only"
-                checked={this.checked}
-              />
-              <label htmlFor="vol50">
-                {/* eslint-disable-line */}
-                <span className="sr-only">Volume Level 50/100</span>
-              </label>
-              <input
-                onChange={this.volume}
-                type="radio"
-                name="volume"
-                value="0.6"
-                id="vol60"
-                className="sr-only"
-                checked={this.checked}
-              />
-              <label htmlFor="vol60">
-                {/* eslint-disable-line */}
-                <span className="sr-only">Volume Level 60/100</span>
-              </label>
-              <input
-                onChange={this.volume}
-                type="radio"
-                name="volume"
-                value="0.7"
-                id="vol70"
-                className="sr-only"
-                checked={this.checked}
-              />
-              <label htmlFor="vol70">
-                {/* eslint-disable-line */}
-                <span className="sr-only">Volume Level 70/100</span>
-              </label>
-              <input
-                onChange={this.volume}
-                type="radio"
-                name="volume"
-                value="0.8"
-                id="vol80"
-                className="sr-only"
-                checked={this.checked}
-              />
-              <label htmlFor="vol80">
-                {/* eslint-disable-line */}
-                <span className="sr-only">Volume Level 80/100</span>
-              </label>
-
-              <input
-                onChange={this.volume}
-                type="radio"
-                name="volume"
-                value="0.9"
-                id="vol90"
-                className="sr-only"
-                checked={this.checked}
-              />
-              <label htmlFor="vol90">
-                {/* eslint-disable-line */}
-                <span className="sr-only">Volume Level 90/100</span>
-              </label>
-
-              <input
-                onChange={this.volume}
-                type="radio"
-                name="volume"
-                value="1"
-                id="vol100"
-                className="sr-only"
-                checked={this.checked}
-              />
-              <label htmlFor="vol100">
-                <span className="sr-only">Volume Level 100/100</span>
-              </label>
+              <VolumeBars />
             </div>
           </div>
         </div>
-        {/* eslint-disable */}
+
         <audio
           ref={audio => (this.audio = audio)}
           onPlay={this.playPause}
@@ -477,7 +275,6 @@ export default class Player extends React.Component {
           onLoadedMetadata={this.groupUpdates}
           src={show.url}
         />
-        {/* eslint-enable */}
       </div>
     );
   }

--- a/components/Player.js
+++ b/components/Player.js
@@ -15,7 +15,7 @@ export default class Player extends React.Component {
     super(props);
 
     let lastPlayed = 0;
-    let lastVolumePref = 0;
+    let lastVolumePref = 0; // ---- I can set the default value here?
 
     // for Server Side Rendering
     if (typeof window !== 'undefined') {
@@ -26,6 +26,7 @@ export default class Player extends React.Component {
       );
 
       if (lp) lastPlayed = JSON.parse(lp).lastPlayed;
+      // Without this bottom line - on refresh its then its not saved
       if (lastVolume) lastVolumePref = JSON.parse(lastVolume).lastVolumePref;
     }
 
@@ -35,14 +36,13 @@ export default class Player extends React.Component {
       duration: 0,
       currentTime: lastPlayed,
       currentVolume: lastVolumePref,
-      checked: false,
       playbackRate: 1,
       timeWasLoaded: lastPlayed !== 0,
       showTooltip: false,
       tooltipPosition: 0,
       tooltipTime: '0:00'
     };
-  }
+  } // END Constructor
 
   componentWillUpdate(nextProps, nextState) {
     this.audio.playbackRate = nextState.playbackRate;
@@ -156,8 +156,7 @@ export default class Player extends React.Component {
   volume = e => {
     this.audio.volume = e.currentTarget.value;
     this.setState({
-      currentVolume: `${e.currentTarget.value}`,
-      checked: !this.state.checked
+      currentVolume: `${e.currentTarget.value}`
     });
   };
 
@@ -194,7 +193,6 @@ export default class Player extends React.Component {
       playbackRate,
       progressTime,
       currentTime,
-      checked,
       duration,
       showTooltip,
       tooltipPosition,
@@ -258,7 +256,6 @@ export default class Player extends React.Component {
             <p>FASTNESS</p>
             <span className="player__speeddisplay">{playbackRate} &times;</span>
           </button>
-
           <div className="player__volume">
             <p>LOUDNESS</p>
             <div className="player__inputs">
@@ -266,7 +263,6 @@ export default class Player extends React.Component {
             </div>
           </div>
         </div>
-
         <audio
           ref={audio => (this.audio = audio)}
           onPlay={this.playPause}

--- a/components/Player.js
+++ b/components/Player.js
@@ -15,7 +15,7 @@ export default class Player extends React.Component {
     super(props);
 
     let lastPlayed = 0;
-    let lastVolumePref = 1; //--- SET DEFAULT ?
+    let lastVolumePref = 1;
     let lastPlaybackRate = 1;
 
     // for Server Side Rendering
@@ -26,9 +26,7 @@ export default class Player extends React.Component {
       const lastPlayback = localStorage.getItem(`lastPlaybackSetting`);
 
       if (lp) lastPlayed = JSON.parse(lp).lastPlayed;
-      // Without this bottom line - on refresh its then its not saved
       if (lastVolume) lastVolumePref = JSON.parse(lastVolume).lastVolumePref;
-      //
       if (lastPlayback)
         lastPlaybackRate = JSON.parse(lastPlayback).lastPlaybackRate;
     }
@@ -90,7 +88,7 @@ export default class Player extends React.Component {
   }
 
   timeUpdate = e => {
-    console.log('Updating Time');
+    // console.log('Updating Time');
     const { show } = this.props;
     const { timeWasLoaded } = this.state;
     console.log(`🌈 ${timeWasLoaded}`);

--- a/components/Player.js
+++ b/components/Player.js
@@ -15,7 +15,7 @@ export default class Player extends React.Component {
     super(props);
 
     let lastPlayed = 0;
-    let lastVolumePref = 0; // ---- I can set the default value here?
+    let lastVolumePref = 1; //-------------- SET DEFAULT ?
 
     // for Server Side Rendering
     if (typeof window !== 'undefined') {
@@ -49,14 +49,15 @@ export default class Player extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    console.log('Hollar1111');
     const { show } = this.props;
     const { currentTime, currentVolume } = this.state;
     if (show.number !== prevProps.show.number) {
       const lp = localStorage.getItem(`lastPlayed${show.number}`);
-      // const lastVolume = localStorage.getItem(
-      //   `lastVolumeSetting${show.number}`
-      // );
       if (lp) {
+        const lastVolume = localStorage.getItem(
+          `lastVolumeSetting${show.number}`
+        );
         const data = JSON.parse(lp);
         const data2 = JSON.parse(lastVolume);
 

--- a/components/Player.js
+++ b/components/Player.js
@@ -21,9 +21,7 @@ export default class Player extends React.Component {
     if (typeof window !== 'undefined') {
       const { show } = this.props;
       const lp = localStorage.getItem(`lastPlayed${show.number}`);
-      const lastVolume = localStorage.getItem(
-        `lastVolumeSetting${show.number}`
-      );
+      const lastVolume = localStorage.getItem(`lastVolumeSetting`);
 
       if (lp) lastPlayed = JSON.parse(lp).lastPlayed;
       // Without this bottom line - on refresh its then its not saved
@@ -55,9 +53,7 @@ export default class Player extends React.Component {
     if (show.number !== prevProps.show.number) {
       const lp = localStorage.getItem(`lastPlayed${show.number}`);
       if (lp) {
-        const lastVolume = localStorage.getItem(
-          `lastVolumeSetting${show.number}`
-        );
+        const lastVolume = localStorage.getItem(`lastVolumeSetting`);
         const data = JSON.parse(lp);
         const data2 = JSON.parse(lastVolume);
 
@@ -75,7 +71,7 @@ export default class Player extends React.Component {
         JSON.stringify({ lastPlayed: currentTime })
       );
       localStorage.setItem(
-        `lastVolumeSetting${show.number}`,
+        `lastVolumeSetting`,
         JSON.stringify({ lastVolumePref: currentVolume })
       );
     }
@@ -111,9 +107,7 @@ export default class Player extends React.Component {
     console.log(`🌈🌈 ${timeWasLoaded}`);
     // Check if the user already had a curent volume
     if (timeWasLoaded) {
-      const lastVolume = localStorage.getItem(
-        `lastVolumeSetting${show.number}`
-      );
+      const lastVolume = localStorage.getItem(`lastVolumeSetting`);
       if (lastVolume) {
         console.log(`🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖 ${lastVolume}`);
         e.currentTarget.volume = JSON.parse(lastVolume).lastVolumePref;

--- a/components/Player.js
+++ b/components/Player.js
@@ -15,17 +15,22 @@ export default class Player extends React.Component {
     super(props);
 
     let lastPlayed = 0;
-    let lastVolumePref = 1; //-------------- SET DEFAULT ?
+    let lastVolumePref = 1; //--- SET DEFAULT ?
+    let lastPlaybackRate = 1;
 
     // for Server Side Rendering
     if (typeof window !== 'undefined') {
       const { show } = this.props;
       const lp = localStorage.getItem(`lastPlayed${show.number}`);
       const lastVolume = localStorage.getItem(`lastVolumeSetting`);
+      const lastPlayback = localStorage.getItem(`lastPlaybackSetting`);
 
       if (lp) lastPlayed = JSON.parse(lp).lastPlayed;
       // Without this bottom line - on refresh its then its not saved
       if (lastVolume) lastVolumePref = JSON.parse(lastVolume).lastVolumePref;
+      //
+      if (lastPlayback)
+        lastPlaybackRate = JSON.parse(lastPlayback).lastPlaybackRate;
     }
 
     this.state = {
@@ -34,7 +39,7 @@ export default class Player extends React.Component {
       duration: 0,
       currentTime: lastPlayed,
       currentVolume: lastVolumePref,
-      playbackRate: 1,
+      playbackRate: lastPlaybackRate,
       timeWasLoaded: lastPlayed !== 0,
       showTooltip: false,
       tooltipPosition: 0,
@@ -47,22 +52,25 @@ export default class Player extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    console.log('Hollar1111');
     const { show } = this.props;
-    const { currentTime, currentVolume } = this.state;
+    const { currentTime, currentVolume, playbackRate } = this.state;
     if (show.number !== prevProps.show.number) {
       const lp = localStorage.getItem(`lastPlayed${show.number}`);
       if (lp) {
         const lastVolume = localStorage.getItem(`lastVolumeSetting`);
+        const lastPlayback = localStorage.getItem(`lastPlaybackSetting`);
         const data = JSON.parse(lp);
         const data2 = JSON.parse(lastVolume);
+        const data3 = JSON.parse(lastPlayback);
 
         this.setState({
           currentTime: data.lastPlayed,
-          currentVolume: data2.lastVolumePref
+          currentVolume: data2.lastVolumePref,
+          playbackRate: data3.lastPlaybackRate
         });
         this.audio.currentTime = data.lastPlayed;
         this.audio.volume = data2.lastVolumePref;
+        this.audio.playbackRate = data3.lastPlaybackRate;
       }
       this.audio.play();
     } else {
@@ -73,6 +81,10 @@ export default class Player extends React.Component {
       localStorage.setItem(
         `lastVolumeSetting`,
         JSON.stringify({ lastVolumePref: currentVolume })
+      );
+      localStorage.setItem(
+        `lastPlaybackSetting`,
+        JSON.stringify({ lastPlaybackRate: playbackRate })
       );
     }
   }
@@ -101,16 +113,27 @@ export default class Player extends React.Component {
   };
 
   volumeUpdate = e => {
-    console.log('Updating Volume');
-    const { show } = this.props;
     const { timeWasLoaded } = this.state;
-    console.log(`🌈🌈 ${timeWasLoaded}`);
     // Check if the user already had a curent volume
     if (timeWasLoaded) {
       const lastVolume = localStorage.getItem(`lastVolumeSetting`);
       if (lastVolume) {
-        console.log(`🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖 ${lastVolume}`);
         e.currentTarget.volume = JSON.parse(lastVolume).lastVolumePref;
+      }
+      this.setState({ timeWasLoaded: false });
+    }
+  };
+
+  playbackRateUpdate = e => {
+    console.log(' 🌈🌈 Updating PlaybackRate');
+    const { timeWasLoaded } = this.state;
+    if (timeWasLoaded) {
+      const lastPlaybackRate = localStorage.getItem(`lastPlaybackSetting`);
+      if (lastPlaybackRate) {
+        console.log(`🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖 ${lastPlaybackRate}`);
+        e.currentTarget.playbackRate = JSON.parse(
+          lastPlaybackRate
+        ).lastPlaybackRate;
       }
       this.setState({ timeWasLoaded: false });
     }
@@ -119,6 +142,7 @@ export default class Player extends React.Component {
   groupUpdates = e => {
     this.timeUpdate(e);
     this.volumeUpdate(e);
+    // this.playbackRateUpdate(e);
   };
 
   togglePlay = () => {

--- a/components/Player.js
+++ b/components/Player.js
@@ -91,13 +91,11 @@ export default class Player extends React.Component {
     // console.log('Updating Time');
     const { show } = this.props;
     const { timeWasLoaded } = this.state;
-    console.log(`🌈 ${timeWasLoaded}`);
     // Check if the user already had a curent time
     if (timeWasLoaded) {
       const lp = localStorage.getItem(`lastPlayed${show.number}`);
 
       if (lp) {
-        console.log(`💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎 ${lp}`);
         e.currentTarget.currentTime = JSON.parse(lp).lastPlayed;
       }
       this.setState({ timeWasLoaded: false });

--- a/components/Player.js
+++ b/components/Player.js
@@ -125,6 +125,7 @@ export default class Player extends React.Component {
     this.timeUpdate(e);
     this.volumeUpdate(e);
   };
+
   togglePlay = () => {
     const { playing } = this.state;
     const method = playing ? 'pause' : 'play';
@@ -261,7 +262,7 @@ export default class Player extends React.Component {
           <div className="player__volume">
             <p>LOUDNESS</p>
             <div className="player__inputs">
-              <VolumeBars />
+              <VolumeBars volume={this.volume} />
             </div>
           </div>
         </div>

--- a/components/Player.js
+++ b/components/Player.js
@@ -124,25 +124,9 @@ export default class Player extends React.Component {
     }
   };
 
-  playbackRateUpdate = e => {
-    console.log(' 🌈🌈 Updating PlaybackRate');
-    const { timeWasLoaded } = this.state;
-    if (timeWasLoaded) {
-      const lastPlaybackRate = localStorage.getItem(`lastPlaybackSetting`);
-      if (lastPlaybackRate) {
-        console.log(`🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖🤖 ${lastPlaybackRate}`);
-        e.currentTarget.playbackRate = JSON.parse(
-          lastPlaybackRate
-        ).lastPlaybackRate;
-      }
-      this.setState({ timeWasLoaded: false });
-    }
-  };
-
   groupUpdates = e => {
     this.timeUpdate(e);
     this.volumeUpdate(e);
-    // this.playbackRateUpdate(e);
   };
 
   togglePlay = () => {

--- a/components/Player.js
+++ b/components/Player.js
@@ -259,7 +259,7 @@ export default class Player extends React.Component {
           <div className="player__volume">
             <p>LOUDNESS</p>
             <div className="player__inputs">
-              <VolumeBars volume={this.volume} />
+              <VolumeBars volume={this.volume} show={show} />
             </div>
           </div>
         </div>

--- a/components/Player.js
+++ b/components/Player.js
@@ -262,7 +262,7 @@ export default class Player extends React.Component {
           <div className="player__volume">
             <p>LOUDNESS</p>
             <div className="player__inputs">
-              <VolumeBars volume={this.volume} show={show} />
+              <VolumeBars volume={this.volume} />
             </div>
           </div>
         </div>

--- a/components/VolumeBars.js
+++ b/components/VolumeBars.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
 
-// data generator
+// data generator -> to create 10 volume bars
 const getItems = count => {
   return Array.from({ length: count }, (v, i) => (i + 1) * 10).map(k => {
     let decimal = k / 100;
@@ -22,42 +22,29 @@ class VolumeBars extends Component {
   componentDidMount() {
     const localKey = `lastVolumeBarsOn`;
     const localStorageRef = localStorage.getItem(localKey);
-
-    console.log('🔥🔥');
-    console.log(localStorageRef);
-    //
     if (localStorageRef) {
       this.setState({ volumeBarList: JSON.parse(localStorageRef) });
     }
   }
 
   componentDidUpdate(prevProps, prevState) {
-    console.log('YOOOOO4444');
-    // console.log(this.state.volumeBarList);
-    //
     const localKey = `lastVolumeBarsOn`;
     const localValue = JSON.stringify(this.state.volumeBarList);
     localStorage.setItem(localKey, localValue);
   }
 
-  //We are going to add "checked" to our array of objects - on click
+  //We are going to track which volume bars are "checked"
   handleOnClick = index => {
     // make a copy of state
     const volumeBarList = [...this.state.volumeBarList];
-    //
-    console.log(`INDEX CLICKED IS ==> ${index}`);
-    //
-    //--- Get the index positions from 0 till index (index clicked)
+    // Get the index positions from 0 till index (index clicked)
     for (let i = 0; i <= index; i++) {
-      console.log(`🍎🍎🍎🍎🍎🍎🍎 ==> ${i}`);
       volumeBarList[i].checked = true;
     }
-    // --- Get the index positions that are leftover from aboves range
+    // Get the index positions of the remaining non-checked
     for (let i = index + 1; i < 10; i++) {
-      console.log(`⭐️⭐️⭐️⭐️⭐️  ${i}`);
       volumeBarList[i].checked = null;
     }
-
     // Update State
     this.setState({
       volumeBarList

--- a/components/VolumeBars.js
+++ b/components/VolumeBars.js
@@ -19,9 +19,30 @@ class VolumeBars extends Component {
     volumeBarList: getItems(10)
   };
 
+  componentDidMount() {
+    //
+    const { show } = this.props;
+    //
+    const localKey = `lastVolumeBarsOn${show.number}`;
+    const localStorageRef = localStorage.getItem(localKey);
+
+    console.log('🔥🔥');
+    console.log(localStorageRef);
+    //
+    if (localStorageRef) {
+      this.setState({ volumeBarList: JSON.parse(localStorageRef) });
+    }
+  }
+
   componentDidUpdate(prevProps, prevState) {
     console.log('YOOOOO4444');
-    console.log(this.state.volumeBarList);
+    // console.log(this.state.volumeBarList);
+    //
+    const { show } = this.props;
+    //
+    const localKey = `lastVolumeBarsOn${show.number}`;
+    const localValue = JSON.stringify(this.state.volumeBarList);
+    localStorage.setItem(localKey, localValue);
   }
 
   //We are going to add "checked" to our array of objects - on click

--- a/components/VolumeBars.js
+++ b/components/VolumeBars.js
@@ -1,0 +1,46 @@
+import React, { Component, Fragment } from 'react';
+
+// fake data generator
+const getItems = count => {
+  return Array.from({ length: count }, (v, i) => (i + 1) * 10).map(k => {
+    let decimal = k / 100;
+    return {
+      // id: `item-${k}`,
+      integer: `${k}`,
+      deci: `${decimal}`,
+      vol: `vol${k}`,
+      level: `Volume LevelLL ${k}/100`
+    };
+  }); // END MAP
+}; // END ARROW
+
+class VolumeBars extends Component {
+  state = {
+    volumeBarList: getItems(10)
+  };
+
+  render() {
+    return (
+      <Fragment>
+        {this.state.volumeBarList.map((item, index) => (
+          <Fragment>
+            <input
+              onChange={this.volume}
+              type="radio"
+              name="volume"
+              value={item.deci}
+              id={item.vol}
+              className="sr-only"
+              checked={this.checked}
+            />
+            <label htmlFor={item.vol}>
+              <span className="sr-only">{item.level}</span>
+            </label>
+          </Fragment>
+        ))}
+      </Fragment>
+    );
+  }
+}
+
+export default VolumeBars;

--- a/components/VolumeBars.js
+++ b/components/VolumeBars.js
@@ -1,15 +1,14 @@
 import React, { Component, Fragment } from 'react';
 
-// fake data generator
+// data generator
 const getItems = count => {
   return Array.from({ length: count }, (v, i) => (i + 1) * 10).map(k => {
     let decimal = k / 100;
     return {
-      // id: `item-${k}`,
       integer: `${k}`,
       deci: `${decimal}`,
       vol: `vol${k}`,
-      level: `Volume LevelLL ${k}/100`
+      level: `Volume Level ${k}/100`
     };
   }); // END MAP
 }; // END ARROW
@@ -23,7 +22,7 @@ class VolumeBars extends Component {
     return (
       <Fragment>
         {this.state.volumeBarList.map((item, index) => (
-          <Fragment>
+          <Fragment key={item.integer}>
             <input
               onChange={this.volume}
               type="radio"

--- a/components/VolumeBars.js
+++ b/components/VolumeBars.js
@@ -8,7 +8,8 @@ const getItems = count => {
       integer: `${k}`,
       deci: `${decimal}`,
       vol: `vol${k}`,
-      level: `Volume Level ${k}/100`
+      level: `Volume Level ${k}/100`,
+      checked: false
     };
   }); // END MAP
 }; // END ARROW
@@ -18,19 +19,45 @@ class VolumeBars extends Component {
     volumeBarList: getItems(10)
   };
 
+  //We are going to add "checked" to our array of objects - on click
+  handleOnClick = index => {
+    // make a copy of state
+    const volumeBarList = [...this.state.volumeBarList];
+    //
+    console.log(`INDEX CLICKED IS ==> ${index}`);
+    //
+    // --- Get the index positions from 0 till index (index clicked)
+    for (let i = 0; i <= index; i++) {
+      console.log(`🍎🍎🍎🍎🍎🍎🍎 ==> ${i}`);
+      volumeBarList[i].checked = true;
+    }
+    // --- Get the index positions that are leftover from aboves range
+    for (let i = index + 1; i < 10; i++) {
+      console.log(`⭐️⭐️⭐️⭐️⭐️  ${i}`);
+      volumeBarList[i].checked = false;
+    }
+
+    // Update State
+    this.setState({
+      volumeBarList
+    });
+  };
+
   render() {
     return (
       <Fragment>
         {this.state.volumeBarList.map((item, index) => (
           <Fragment key={item.integer}>
             <input
+              onClick={() => {
+                this.handleOnClick(index);
+              }}
               onChange={this.props.volume}
               type="radio"
               name="volume"
               value={item.deci}
               id={item.vol}
               className="sr-only"
-              checked={this.props.checked}
             />
             <label htmlFor={item.vol}>
               <span className="sr-only">{item.level}</span>
@@ -41,5 +68,7 @@ class VolumeBars extends Component {
     );
   }
 }
+// TO DO
+// remove checked stuff from player.js
 
 export default VolumeBars;

--- a/components/VolumeBars.js
+++ b/components/VolumeBars.js
@@ -1,5 +1,7 @@
 import React, { Component, Fragment } from 'react';
 
+// TODO Fix all eslint issues
+
 // data generator -> to create 10 volume bars
 const getItems = count => {
   return Array.from({ length: count }, (v, i) => (i + 1) * 10).map(k => {

--- a/components/VolumeBars.js
+++ b/components/VolumeBars.js
@@ -9,7 +9,7 @@ const getItems = count => {
       deci: `${decimal}`,
       vol: `vol${k}`,
       level: `Volume Level ${k}/100`,
-      checked: false
+      checked: null
     };
   }); // END MAP
 }; // END ARROW
@@ -19,6 +19,10 @@ class VolumeBars extends Component {
     volumeBarList: getItems(10)
   };
 
+  componentDidUpdate(prevProps, prevState) {
+    console.log('YOOOOO4444');
+  }
+
   //We are going to add "checked" to our array of objects - on click
   handleOnClick = index => {
     // make a copy of state
@@ -26,7 +30,7 @@ class VolumeBars extends Component {
     //
     console.log(`INDEX CLICKED IS ==> ${index}`);
     //
-    // --- Get the index positions from 0 till index (index clicked)
+    //--- Get the index positions from 0 till index (index clicked)
     for (let i = 0; i <= index; i++) {
       console.log(`🍎🍎🍎🍎🍎🍎🍎 ==> ${i}`);
       volumeBarList[i].checked = true;
@@ -34,7 +38,7 @@ class VolumeBars extends Component {
     // --- Get the index positions that are leftover from aboves range
     for (let i = index + 1; i < 10; i++) {
       console.log(`⭐️⭐️⭐️⭐️⭐️  ${i}`);
-      volumeBarList[i].checked = false;
+      volumeBarList[i].checked = null;
     }
 
     // Update State
@@ -68,7 +72,5 @@ class VolumeBars extends Component {
     );
   }
 }
-// TO DO
-// remove checked stuff from player.js
 
 export default VolumeBars;

--- a/components/VolumeBars.js
+++ b/components/VolumeBars.js
@@ -20,10 +20,7 @@ class VolumeBars extends Component {
   };
 
   componentDidMount() {
-    //
-    const { show } = this.props;
-    //
-    const localKey = `lastVolumeBarsOn${show.number}`;
+    const localKey = `lastVolumeBarsOn`;
     const localStorageRef = localStorage.getItem(localKey);
 
     console.log('🔥🔥');
@@ -38,9 +35,7 @@ class VolumeBars extends Component {
     console.log('YOOOOO4444');
     // console.log(this.state.volumeBarList);
     //
-    const { show } = this.props;
-    //
-    const localKey = `lastVolumeBarsOn${show.number}`;
+    const localKey = `lastVolumeBarsOn`;
     const localValue = JSON.stringify(this.state.volumeBarList);
     localStorage.setItem(localKey, localValue);
   }

--- a/components/VolumeBars.js
+++ b/components/VolumeBars.js
@@ -9,7 +9,7 @@ const getItems = count => {
       deci: `${decimal}`,
       vol: `vol${k}`,
       level: `Volume Level ${k}/100`,
-      checked: null
+      checked: true
     };
   }); // END MAP
 }; // END ARROW
@@ -21,6 +21,7 @@ class VolumeBars extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     console.log('YOOOOO4444');
+    console.log(this.state.volumeBarList);
   }
 
   //We are going to add "checked" to our array of objects - on click
@@ -63,7 +64,14 @@ class VolumeBars extends Component {
               id={item.vol}
               className="sr-only"
             />
-            <label htmlFor={item.vol}>
+            <label
+              htmlFor={item.vol}
+              style={
+                item.checked
+                  ? { background: '#03fff3' }
+                  : { background: '#e4e4e4' }
+              }
+            >
               <span className="sr-only">{item.level}</span>
             </label>
           </Fragment>

--- a/components/VolumeBars.js
+++ b/components/VolumeBars.js
@@ -24,13 +24,13 @@ class VolumeBars extends Component {
         {this.state.volumeBarList.map((item, index) => (
           <Fragment key={item.integer}>
             <input
-              onChange={this.volume}
+              onChange={this.props.volume}
               type="radio"
               name="volume"
               value={item.deci}
               id={item.vol}
               className="sr-only"
-              checked={this.checked}
+              checked={this.props.checked}
             />
             <label htmlFor={item.vol}>
               <span className="sr-only">{item.level}</span>


### PR DESCRIPTION
Reference: [Issue #234](https://github.com/wesbos/Syntax/issues/234) 😄

The playbackRate and Volume setting are now both placed in LocalStorage. That logic lives in Player.js.

I also made a few additional changes. Previously, Player.js had 10 hardcoded input + label tags that represented the volume bars. I refactored this, by creating a new component called VolumeBars.js. Now Player.js displays the volume bars ( `<VolumeBars volume={this.volume} />` ) via the VolumeBars.js imported component.

VolumeBars.js now generates these same 10 input/label blocks with the same unique attribute settings they each had before. The benefit is I generated these 10 blocks by just mapping over one as a template in the VolumeBars.js component. Now this better follows the DRY (don't repeat yourself) principal and removes a lot of repeated code from Player.js, so its cleaner.

VolumeBars.js also tracks, via LocalStorage, which volume bars the user has clicked (the object key is named "checked"). If this is not done, then when the users volume setting is restored on refresh the volume setting number in LocalStorage will be restored correctly, but the volume bar CSS will incorrectly show all volume bars "green". By now tracking which volume bars the user "checked", LocalStorage will restore the correct CSS for the volume bars to match the other volume setting number in LocalStorage. Now on refresh, the CSS for the volume bars correctly represent the Volume Setting Number.