### PR TITLE
Fix show date formatting

### DIFF
--- a/lib/getShows.js
+++ b/lib/getShows.js
@@ -29,7 +29,7 @@ const loadShows = async () => {
         ...show.meta,
         html: show.html,
         notesFile: files[i],
-        displayDate: format(parseFloat(show.meta.date), 'MMM do, YYYY'),
+        displayDate: format(parseFloat(show.meta.date), 'MMM Do, YYYY'),
         number,
       };
     }) // flatten


### PR DESCRIPTION
The latest episode (105: Hasty Treat - CSS and JS Pointer Events) currently has an episode date of Dec 31st, 2019 on all my devices (all set to UTC+0):

![image](https://user-images.githubusercontent.com/236781/50590479-1b1e8380-0e83-11e9-8d10-98a809372968.png)

Pull Request #87 included a fix for a bug(?) in `date-fns` but per some testing I think this is now causing the incorrect date to show up and the old formatting string (`MMM Do, YYYY`) results in the correct behaviour.