### PR TITLE
fix links to shameless plugs

### DIFF
--- a/shows/140 - potluck.md
+++ b/shows/140 - potluck.md
@@ -68,8 +68,8 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 * Wes: [DeWalt Oscillating Tool](https://amzn.to/2Iz7jNQ)
 
 ## Shameless Plugs
-* Wes: [Wes' Courses](wesbos.com/courses) — use coupon code "syntax" at checkout and get and extra $10 off.
-* Scott: [Animating React](leveluptutorials.com/pro)
+* Wes: [Wes' Courses](https://wesbos.com/courses) — use coupon code "syntax" at checkout and get and extra $10 off.
+* Scott: [Animating React](https://leveluptutorials.com/pro)
 
 ## Tweet us your tasty treats!
 * [Scott's Instagram](https://www.instagram.com/stolinski/)


### PR DESCRIPTION
The previous links directed toward a github 404 page, perhaps looking for a local page.

```diff
--   wesbos.com/courses
++ https://wesbos.com/courses
```

Scott's plug also refers to its pro page. I don't know if it is intentional, but the particular series "Animating React" is found at [this url](https://www.leveluptutorials.com/tutorials/animating-react).