### PR TITLE
Update 146 - Fix Shameless Plugs urls (https:// missing)

### DIFF
--- a/shows/146 - CSS cool parts.md
+++ b/shows/146 - CSS cool parts.md
@@ -60,8 +60,8 @@ Sanity.io is a real-time headless CMS with a fully customizable Content Studio b
 * Wes: [Digital Calipers](https://amzn.to/2JkucEn)
 
 ## Shameless Plugs
-* Wes: [Wes' Courses](wesbos.com/courses) — use coupon code "syntax" at checkout and get and extra $10 off.
-* Scott: [Animating React](leveluptutorials.com/pro)
+* Wes: [Wes' Courses](https://wesbos.com/courses) — use coupon code "syntax" at checkout and get and extra $10 off.
+* Scott: [Animating React](https://www.leveluptutorials.com/pro)
 
 ## Tweet us your tasty treats!
 * [Scott's Instagram](https://www.instagram.com/stolinski/)


### PR DESCRIPTION
Both Wes' and Scott's shameless plugs urls were missing the initial "https://". The urls led to "https://syntax.fm/wesbos.com/courses" and "https://syntax.fm/leveluptutorials.com/pro" respectively.