### PR TITLE
Added https:// to the Shameless Plugs in E146

### DIFF
--- a/shows/146 - CSS cool parts.md
+++ b/shows/146 - CSS cool parts.md
@@ -60,8 +60,8 @@ Sanity.io is a real-time headless CMS with a fully customizable Content Studio b
 * Wes: [Digital Calipers](https://amzn.to/2JkucEn)
 
 ## Shameless Plugs
-* Wes: [Wes' Courses](wesbos.com/courses) — use coupon code "syntax" at checkout and get and extra $10 off.
-* Scott: [Animating React](leveluptutorials.com/pro)
+* Wes: [Wes' Courses](https://wesbos.com/courses) — use coupon code "syntax" at checkout and get and extra $10 off.
+* Scott: [Animating React](https://leveluptutorials.com/pro)
 
 ## Tweet us your tasty treats!
 * [Scott's Instagram](https://www.instagram.com/stolinski/)


### PR DESCRIPTION
Added https:// to the links for Shameless Plugs. Otherwise, the pages were going to https://syntax.fm/show/146/wesbos.com/courses and https://syntax.fm/show/146/leveluptutorials.com/pro.