### PR TITLE
Remove focus outline from body

### DIFF
--- a/styles/_layout.styl
+++ b/styles/_layout.styl
@@ -5,6 +5,8 @@
     background white
     padding 2rem
     font-size 1.7rem
+  &:focus
+    outline: none    
   @media (max-width: 1000px)
     padding 0 2rem
 


### PR DESCRIPTION
When I click on layout body this focus outline appears
![image](https://user-images.githubusercontent.com/7611746/63092377-5fc6dd00-bf83-11e9-9b54-6720963b0d88.png)
