### PR TITLE
Remove node_modules tip in Episode 181

### DIFF
--- a/shows/181 - automating stuff.md
+++ b/shows/181 - automating stuff.md
@@ -18,6 +18,10 @@ If you want to know what's happening with your errors, track them with [Sentry](
 
 13:16 - Bash scripts & aliases
 
+17:06 - Remove node_modules
+
+* `find . -name "node_modules" -type d -prune -exec rm -rf '{}' +`
+
 18:43 - Other
 
 ## Links


### PR DESCRIPTION
Scott gave a tip about removing node_modules recursively in Episode 181. He sent me this solution in a DM on Twitter.