### PR TITLE
Remove direct DOM manipulation 💩

### DIFF
--- a/components/Player.js
+++ b/components/Player.js
@@ -7,6 +7,7 @@ import VolumeBars from './VolumeBars';
 export default class Player extends React.Component {
   static propTypes = {
     show: PropTypes.object.isRequired,
+    onPlayPause: PropTypes.func,
   };
 
   constructor(props) {
@@ -146,8 +147,7 @@ export default class Player extends React.Component {
 
   playPause = () => {
     this.setState({ playing: !this.audio.paused });
-    const method = this.audio.paused ? 'add' : 'remove';
-    document.querySelector('.bars').classList[method]('bars--paused'); // 💩
+    this.props.onPlayPause(this.audio)
   };
 
   volume = e => {

--- a/components/Show.js
+++ b/components/Show.js
@@ -11,6 +11,7 @@ export default class Show extends React.Component {
     currentPlaying: PropTypes.string.isRequired,
     currentShow: PropTypes.string.isRequired,
     setCurrentPlaying: PropTypes.func.isRequired,
+    isPlaying: PropTypes.bool
   };
 
   changeURL = (e, show) => {
@@ -20,7 +21,7 @@ export default class Show extends React.Component {
   };
 
   render() {
-    const { show, currentPlaying, currentShow, setCurrentPlaying } = this.props;
+    const { show, currentPlaying, currentShow, setCurrentPlaying, isPlaying } = this.props;
     return (
       <div
         className={`show ${
@@ -39,7 +40,7 @@ export default class Show extends React.Component {
 
         <div className="show__playcontrols">
           {currentPlaying === show.displayNumber ? (
-            <Bars />
+            <Bars isPlaying={isPlaying}/>
           ) : (
             <button
               type="button"

--- a/components/ShowList.js
+++ b/components/ShowList.js
@@ -7,6 +7,7 @@ const ShowList = ({
   currentPlaying,
   currentShow,
   setCurrentPlaying,
+  isPlaying,
 }) => (
   <div className="showList">
     {shows.map(show => (
@@ -16,6 +17,7 @@ const ShowList = ({
         currentShow={currentShow}
         key={show.number}
         show={show}
+        isPlaying={isPlaying}
       />
     ))}
     <div className="show show--dummy" />

--- a/components/bars.js
+++ b/components/bars.js
@@ -1,5 +1,5 @@
-const Bars = () => (
-  <div className="bars bars--paused">
+const Bars = ({isPlaying}) => (
+  <div className={`bars ${isPlaying ? '' : 'bars--paused'}`}>
     <div className="bar" />
     <div className="bar" />
     <div className="bar" />

--- a/pages/index.js
+++ b/pages/index.js
@@ -25,6 +25,7 @@ export default withRouter(
       this.state = {
         currentShow,
         currentPlaying: currentShow,
+        isPlaying: false,
       };
     }
 
@@ -46,9 +47,13 @@ export default withRouter(
       this.setState({ currentPlaying });
     };
 
+    setIsPlaying = (isPlaying) => {
+      this.setState({isPlaying})
+    }
+
     render() {
       const { shows = [], baseURL } = this.props;
-      const { currentShow, currentPlaying } = this.state;
+      const { currentShow, currentPlaying, isPlaying } = this.state;
       // Currently Shown shownotes
       const show =
         shows.find(showItem => showItem.displayNumber === currentShow) ||
@@ -63,12 +68,13 @@ export default withRouter(
           <Meta show={show} baseURL={baseURL} />
           <div className="wrapper">
             <main className="show-wrap" id="main" tabIndex="-1">
-              <Player show={current} />
+              <Player show={current} onPlayPause={a => this.setIsPlaying(!a.paused)}/>
               <ShowList
                 shows={shows}
                 currentShow={currentShow}
                 currentPlaying={currentPlaying}
                 setCurrentPlaying={this.setCurrentPlaying}
+                isPlaying={isPlaying}
               />
               <ShowNotes
                 show={show}


### PR DESCRIPTION
The current code manipulates the dom directly to have achieve animating the "hifi bars" in the showlist when the podcast player is playing. This is not idiomatic react.

This changes fixes that by lifting "isPlaying" up into the parent component (`IndexPage`) and then propegating it down to the `Bars` component.