### PR TITLE
(Chore): Refactor and Simplify LocalStorage

### DIFF
--- a/components/Player.js
+++ b/components/Player.js
@@ -3,103 +3,89 @@ import PropTypes from 'prop-types';
 import { FaPlay, FaPause } from 'react-icons/fa';
 import formatTime from '../lib/formatTime';
 import VolumeBars from './VolumeBars';
+import ls from '../lib/localstorage-object'
+import upgradeLocalStorage from '../lib/upgrade-localstorage'
 
 export default class Player extends React.Component {
   static propTypes = {
     show: PropTypes.object.isRequired,
+    enableLocalStorage: PropTypes.bool,
   };
+
+  static defaultProps = {
+    enableLocalStorage: true,
+  }
 
   constructor(props) {
     super(props);
 
-    let lastPlayed = 0;
-    let lastVolumePref = 1;
-    let lastPlaybackRate = 1;
-
-    // for Server Side Rendering
-    if (typeof window !== 'undefined') {
-      const { show } = this.props;
-      const lp = localStorage.getItem(`lastPlayed${show.number}`);
-      const lastVolume = localStorage.getItem(`lastVolumeSetting`);
-      const lastPlayback = localStorage.getItem(`lastPlaybackSetting`);
-
-      if (lp) lastPlayed = JSON.parse(lp).lastPlayed; //eslint-disable-line
-      if (lastVolume) lastVolumePref = JSON.parse(lastVolume).lastVolumePref; //eslint-disable-line
-      if (lastPlayback)
-        lastPlaybackRate = JSON.parse(lastPlayback).lastPlaybackRate; //eslint-disable-line
-    }
-
-    this.state = {
+    const initialState = {
       progressTime: 50,
       playing: false,
       duration: 0,
-      currentTime: lastPlayed,
-      currentVolume: lastVolumePref,
-      playbackRate: lastPlaybackRate,
-      timeWasLoaded: lastPlayed !== 0,
+      currentTime: 0,
+      currentVolume: 1,
+      playbackRate: 1,
+      timeWasLoaded: false,
       showTooltip: false,
       tooltipPosition: 0,
-      tooltipTime: '0:00',
-    };
+      tooltipTime: '0:00'
+    }
+
+    // for Server Side Rendering
+    if (typeof window !== 'undefined' && this.props.enableLocalStorage) {
+
+      upgradeLocalStorage()
+
+      const { show } = this.props;
+      const currentTimeLabel = `currentTime${show.number}`
+      
+      if (ls.currentVolume) initialState.currentVolume = ls.currentVolume
+      if (ls.playbackRate) initialState.playbackRate = ls.playbackRate
+      if (ls[currentTimeLabel]) initialState.currentTime = ls[currentTimeLabel]
+
+    }
+
+    initialState.timeWasLoaded = initialState.lastPlayed !== 0,
+    this.state = initialState
   } // END Constructor
 
   componentWillUpdate(nextProps, nextState) { //eslint-disable-line
     this.audio.playbackRate = nextState.playbackRate;
   }
 
-  componentDidUpdate(prevProps, prevState) { //eslint-disable-line
+  componentDidUpdate(prevProps, prevState) {
+    if (!this.props.enableLocalStorage) return
+
     const { show } = this.props;
-    const { currentTime, currentVolume, playbackRate } = this.state;
-    if (show.number !== prevProps.show.number) {
-      const lp = localStorage.getItem(`lastPlayed${show.number}`);
-      if (lp) {
-        const lastVolume = localStorage.getItem(`lastVolumeSetting`);
-        const lastPlayback = localStorage.getItem(`lastPlaybackSetting`);
-        const data = JSON.parse(lp);
-        const data2 = JSON.parse(lastVolume);
-        const data3 = JSON.parse(lastPlayback);
-        // eslint-disable-next-line
-        this.setState({
-          currentTime: data.lastPlayed,
-          currentVolume: data2.lastVolumePref,
-          playbackRate: data3.lastPlaybackRate,
-        });
-        this.audio.currentTime = data.lastPlayed;
-        this.audio.volume = data2.lastVolumePref;
-        this.audio.playbackRate = data3.lastPlaybackRate;
-      }
+    const currentTimeLabel = `currentTime${show.number}`
+    if (show.number !== prevProps.show.number) { //show changed
+      const currentTime = ls[currentTimeLabel]
+      this.audio.currentTime = currentTime
+      this.setState({currentTime})
       this.audio.play();
-    } else {
-      localStorage.setItem(
-        `lastPlayed${show.number}`,
-        JSON.stringify({ lastPlayed: currentTime })
-      );
-      localStorage.setItem(
-        `lastVolumeSetting`,
-        JSON.stringify({ lastVolumePref: currentVolume })
-      );
-      localStorage.setItem(
-        `lastPlaybackSetting`,
-        JSON.stringify({ lastPlaybackRate: playbackRate })
-      );
+    }
+    else {
+      ls[currentTimeLabel] = this.state.currentTime
+      ls.currentVolume = this.state.currentVolume
+      ls.playbackRate = this.state.playbackRate
     }
   }
 
   timeUpdate = e => {
     // console.log('Updating Time');
     const { show } = this.props;
+    const currentTimeLabel = `currentTime${show.number}`
+
     const { timeWasLoaded } = this.state;
     // Check if the user already had a curent time
     if (timeWasLoaded) {
-      const lp = localStorage.getItem(`lastPlayed${show.number}`);
-
-      if (lp) {
-        e.currentTarget.currentTime = JSON.parse(lp).lastPlayed;
+      if (this.props.enableLocalStorage) {
+        e.currentTarget.currentTime = ls[currentTimeLabel]
       }
       this.setState({ timeWasLoaded: false });
     } else {
       const { currentTime = 0, duration = 0 } = e.currentTarget;
-
       const progressTime = (currentTime / duration) * 100;
       if (Number.isNaN(progressTime)) return;
       this.setState({ progressTime, currentTime, duration });

--- a/lib/localstorage-object.js
+++ b/lib/localstorage-object.js
@@ -1,0 +1,67 @@
+function LocalStorageObject() {   
+}
+
+LocalStorageObject.prototype.getAll = function() {
+    if (!localStorage) return {}
+
+    const result = {}
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        const value = JSON.parse(localStorage.getItem(key))
+        result[key] = value
+    }
+    return result
+}
+
+LocalStorageObject.prototype.clear = function () {
+    if (!localStorage) return
+
+    localStorage.clear()
+}
+
+LocalStorageObject.prototype.apply = function(newObj) {
+    if(!localStorage) return
+
+    Object.entries(newObj).forEach(([key, value]) => {
+        this[key] = value
+    })
+}
+
+LocalStorageObject.prototype.has = function(key) {
+    if(!localStorage) return
+
+    localStorage.getItem(key) !== null
+}
+
+LocalStorageObject.prototype.remove = function(key) {
+    if(!localStorage) return
+
+    localStorage.removeItem(key)
+
+}
+
+
+const localStorageHandler = {
+    
+    get: function(obj, key) {
+        if (obj[key]) return obj[key]
+        if (!localStorage) return undefined
+
+        const string = localStorage.getItem(key)
+        const value = JSON.parse(string)
+        return value
+    },
+
+    set: function(obj, key, value) {
+        if (!localStorage) return
+
+        const string = JSON.stringify(value)
+        localStorage.setItem(key,string)
+        return string
+    },
+
+}
+
+const ls = new Proxy(new LocalStorageObject(), localStorageHandler)
+
+export default ls

--- a/lib/upgrade-localstorage.js
+++ b/lib/upgrade-localstorage.js
@@ -1,0 +1,38 @@
+import ls from './localstorage-object'
+
+function upgradeLocalStorage() {
+  const { newItems } = convertOldLsItemsToNewLsItems(ls.getAll())
+  ls.clear()
+  ls.apply(newItems)
+}
+
+function convertOldLsItemsToNewLsItems(oldItemsSource) {
+  const oldItems = { ...oldItemsSource }
+  const newItems = {}
+  Object.entries(oldItems).filter(([oldKey]) => oldKey.startsWith('lastPlayed')).forEach(([oldKey, oldValue]) => {
+    const newKey = oldKey.replace('lastPlayed', 'currentTime')
+    const newValue = oldValue.lastPlayed
+    newItems[newKey] = newValue
+    delete oldItems[oldKey]
+  })
+
+  if (oldItems.lastVolumeSetting) {
+    newItems.currentVolume = oldItems.lastVolumeSetting.lastVolumePref
+    delete oldItems.lastVolumeSetting
+  }
+  if (oldItems.lastPlaybackSetting) {
+    newItems.playbackRate = oldItems.lastPlaybackSetting.lastPlaybackRate
+    delete oldItems.lastPlaybackSetting
+  }
+  if (oldItems.lastVolumeSetting) {
+    newItems.currentVolume = oldItems.lastVolumeSetting.lastVolumePref
+    delete oldItems.lastVolumeSetting
+  }
+
+  Object.assign(newItems, oldItems)
+
+  return { oldItemsSource, newItems }
+
+}
+
+export default upgradeLocalStorage


### PR DESCRIPTION
This change simplifies the use of localStorage in the Player component in the following ways:
- Renames localStorage variables to align with the names of variables in the component
- Abstracts away the tedium of going to and from JSON text through a localStorageObject module

It also includes a converter to go from the old localStorage variables to the new schema