### PR TITLE
Feature/episode queue

### DIFF
--- a/components/Player.js
+++ b/components/Player.js
@@ -6,7 +6,10 @@ import VolumeBars from './VolumeBars';
 
 export default class Player extends React.Component {
   static propTypes = {
-    show: PropTypes.object.isRequired
+    show: PropTypes.object.isRequired,
+    currentQueue: PropTypes.array.isRequired,
+    removeShowFromQueue: PropTypes.func.isRequired,
+    setCurrentPlaying: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -183,6 +186,17 @@ export default class Player extends React.Component {
     this.setState({ playbackRate });
   };
 
+  // Play next episode in the queue
+  playNext = () => {
+    console.log("starting next!!")
+    const { currentQueue, removeShowFromQueue, setCurrentPlaying } = this.props
+    if(currentQueue.length) {
+      const nextEpisode = currentQueue[0];
+      removeShowFromQueue(nextEpisode);
+      setCurrentPlaying(nextEpisode);
+    }
+  }
+
   render() {
     const { show } = this.props;
     const {
@@ -269,6 +283,7 @@ export default class Player extends React.Component {
           ref={audio => (this.audio = audio)}
           onPlay={this.playPause}
           onPause={this.playPause}
+          onEnded={this.playNext}
           onTimeUpdate={this.timeUpdate}
           onVolumeChange={this.volumeUpdate}
           onLoadedMetadata={this.groupUpdates}

--- a/components/Show.js
+++ b/components/Show.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import slug from 'speakingurl';
 import Router from 'next/router';
-import { FaPlay, FaPlus } from 'react-icons/fa';
+import { FaPlay, FaPlus, FaMinus } from 'react-icons/fa';
 import Bars from './bars';
 
 export default class Show extends React.Component {
@@ -12,6 +12,8 @@ export default class Show extends React.Component {
     currentShow: PropTypes.string.isRequired,
     setCurrentPlaying: PropTypes.func.isRequired,
     addShowToQueue: PropTypes.func.isRequired,
+    currentQueue: PropTypes.array.isRequired,
+    removeShowFromQueue: PropTypes.func.isRequired
   };
 
   changeURL = (e, show) => {
@@ -21,7 +23,7 @@ export default class Show extends React.Component {
   };
 
   render() {
-    const { show, currentPlaying, currentShow, setCurrentPlaying, addShowToQueue } = this.props;
+    const { show, currentPlaying, currentShow, setCurrentPlaying, addShowToQueue, currentQueue, removeShowFromQueue } = this.props;
     return (
       <div
         className={`show ${
@@ -43,14 +45,25 @@ export default class Show extends React.Component {
             <Bars />
           ) : (
             <>
-            <button
-              type="button"
-              onClick={() => addShowToQueue(show.displayNumber)}
-              className="show__play"
-              title="add to queue"
-            >
-              <FaPlus />
-            </button>
+            { !currentQueue.includes(show.displayNumber) ? (
+              <button
+                type="button"
+                onClick={() => addShowToQueue(show.displayNumber)}
+                className="show__play"
+                title="add to queue"
+              >
+                <FaPlus />
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => removeShowFromQueue(show.displayNumber)}
+                className="show__play"
+                title="remove frome queue"
+              >
+                <FaMinus />
+              </button>
+            )}
             <button
               type="button"
               onClick={() => setCurrentPlaying(show.displayNumber)}

--- a/components/Show.js
+++ b/components/Show.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import slug from 'speakingurl';
 import Router from 'next/router';
-import { FaPlay } from 'react-icons/fa';
+import { FaPlay, FaPlus } from 'react-icons/fa';
 import Bars from './bars';
 
 export default class Show extends React.Component {
@@ -11,6 +11,7 @@ export default class Show extends React.Component {
     currentPlaying: PropTypes.string.isRequired,
     currentShow: PropTypes.string.isRequired,
     setCurrentPlaying: PropTypes.func.isRequired,
+    addShowToQueue: PropTypes.func.isRequired,
   };
 
   changeURL = (e, show) => {
@@ -20,7 +21,7 @@ export default class Show extends React.Component {
   };
 
   render() {
-    const { show, currentPlaying, currentShow, setCurrentPlaying } = this.props;
+    const { show, currentPlaying, currentShow, setCurrentPlaying, addShowToQueue } = this.props;
     return (
       <div
         className={`show ${
@@ -41,6 +42,15 @@ export default class Show extends React.Component {
           {currentPlaying === show.displayNumber ? (
             <Bars />
           ) : (
+            <>
+            <button
+              type="button"
+              onClick={() => addShowToQueue(show.displayNumber)}
+              className="show__play"
+              title="add to queue"
+            >
+              <FaPlus />
+            </button>
             <button
               type="button"
               onClick={() => setCurrentPlaying(show.displayNumber)}
@@ -49,6 +59,7 @@ export default class Show extends React.Component {
             >
               <FaPlay />
             </button>
+            </>
           )}
         </div>
       </div>

--- a/components/ShowList.js
+++ b/components/ShowList.js
@@ -7,11 +7,13 @@ const ShowList = ({
   currentPlaying,
   currentShow,
   setCurrentPlaying,
+  addShowToQueue
 }) => (
   <div className="showList">
     {shows.map(show => (
       <Show
         setCurrentPlaying={setCurrentPlaying}
+        addShowToQueue={addShowToQueue}
         currentPlaying={currentPlaying}
         currentShow={currentShow}
         key={show.number}

--- a/components/ShowList.js
+++ b/components/ShowList.js
@@ -7,8 +7,12 @@ const ShowList = ({
   currentPlaying,
   currentShow,
   setCurrentPlaying,
-  addShowToQueue
-}) => (
+  addShowToQueue,
+  currentQueue,
+  removeShowFromQueue
+}) => {
+
+  return(
   <div className="showList">
     {shows.map(show => (
       <Show
@@ -16,6 +20,8 @@ const ShowList = ({
         addShowToQueue={addShowToQueue}
         currentPlaying={currentPlaying}
         currentShow={currentShow}
+        currentQueue={currentQueue}
+        removeShowFromQueue={removeShowFromQueue}
         key={show.number}
         show={show}
       />
@@ -23,6 +29,7 @@ const ShowList = ({
     <div className="show show--dummy" />
   </div>
 );
+}
 
 ShowList.propTypes = {
   shows: PropTypes.array.isRequired,

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,9 +21,13 @@ export default withRouter(
       super();
       const currentShow =
         props.router.query.number || props.shows[0].displayNumber;
+
       // Get the current episode queue or initialize it if it doesnt exist
-      const episodeQueueString = localStorage.getItem("episodeQueue")
-      const currentQueue = episodeQueueString ? JSON.parse(episodeQueueString) : []
+      let currentQueue = []
+      if(typeof window !== "undefined") {
+        const episodeQueueString = localStorage.getItem("episodeQueue")
+        currentQueue = JSON.parse(episodeQueueString)
+      }
 
       this.state = {
         currentShow,
@@ -89,7 +93,12 @@ export default withRouter(
           <Meta show={show} baseURL={baseURL} />
           <div className="wrapper">
             <main className="show-wrap" id="main" tabIndex="-1">
-              <Player show={current} />
+              <Player
+               show={current}
+               currentQueue={this.state.currentQueue}
+               removeShowFromQueue={this.removeShowFromQueue}
+               setCurrentPlaying={this.setCurrentPlaying}
+              />
               <ShowList
                 shows={shows}
                 currentShow={currentShow}

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,10 +21,14 @@ export default withRouter(
       super();
       const currentShow =
         props.router.query.number || props.shows[0].displayNumber;
+      // Get the current episode queue or initialize it if it doesnt exist
+      const episodeQueueString = localStorage.getItem("episodeQueue")
+      const currentQueue = episodeQueueString ? JSON.parse(episodeQueueString) : []
 
       this.state = {
         currentShow,
         currentPlaying: currentShow,
+        currentQueue,
       };
     }
 
@@ -47,7 +51,25 @@ export default withRouter(
     };
 
     addShowToQueue = (show) => {
-      console.log(`Added ${show} to queue!`)
+      console.log(`Added ${show} to queue`)
+      const newQueue = [...this.state.currentQueue, show]
+      this.setState({
+        currentQueue: newQueue
+      })
+      if (typeof window !== 'undefined') {
+        localStorage.setItem("episodeQueue", JSON.stringify(newQueue));
+      }
+    }
+
+    removeShowFromQueue = (show) => {
+      console.log(`Removing ${show} from queue`)
+      const newQueue = this.state.currentQueue.filter(queueItem => queueItem !== show);
+      this.setState({
+        currentQueue: newQueue
+      })
+      if (typeof window !== 'undefined') {
+        localStorage.setItem("episodeQueue", JSON.stringify(newQueue));
+      }
     }
 
     render() {
@@ -74,6 +96,8 @@ export default withRouter(
                 currentPlaying={currentPlaying}
                 setCurrentPlaying={this.setCurrentPlaying}
                 addShowToQueue={this.addShowToQueue}
+                currentQueue={this.state.currentQueue}
+                removeShowFromQueue={this.removeShowFromQueue}
               />
               <ShowNotes
                 show={show}

--- a/pages/index.js
+++ b/pages/index.js
@@ -46,6 +46,10 @@ export default withRouter(
       this.setState({ currentPlaying });
     };
 
+    addShowToQueue = (show) => {
+      console.log(`Added ${show} to queue!`)
+    }
+
     render() {
       const { shows = [], baseURL } = this.props;
       const { currentShow, currentPlaying } = this.state;
@@ -69,6 +73,7 @@ export default withRouter(
                 currentShow={currentShow}
                 currentPlaying={currentPlaying}
                 setCurrentPlaying={this.setCurrentPlaying}
+                addShowToQueue={this.addShowToQueue}
               />
               <ShowNotes
                 show={show}

--- a/styles/_show.styl
+++ b/styles/_show.styl
@@ -14,7 +14,7 @@
     display flex
     align-items center
     justify-content center
-    width 5rem
+    width 10rem
     flex-shrink 0
     padding 1rem
     button


### PR DESCRIPTION
My first go at a contribution to an open source project! ✌  

Pretty much just adds an "Add to queue" button (indicated by a plus) next to the play button of an episode and keeps a track of the episode number in an array in state of `index.js` and also saves the queue over to localStorage similar to how the other player controls are handled.

 Queued episodes start playing automatically after the current episode finishes and can also be removed manually by pressing the minus button - which is what the original plus button turns into when the episode is originally queued. 
