### PR TITLE
Fixing "." placement in download URL

### DIFF
--- a/shows/224 - serverless.md
+++ b/shows/224 - serverless.md
@@ -2,7 +2,7 @@
 number: 224
 title: Serverless / Cloud Functions - Part 1
 date: 1582120800347
-url: https://traffic.libsyn.com/syntax/Syntax.224mp3
+url: https://traffic.libsyn.com/syntax/Syntax224.mp3
 ---
 
 In this episode of Syntax, Scott and Wes talk about serverless and cloud providers - the benefits, limitations, providers and more!


### PR DESCRIPTION
PR #466 seems to have broken the download URL for this episode via an incorrect "." placement.

This commit just moves it to the correct location to fix the URL so that it no longer results in a 404 on the website.