### PR TITLE
Resolved issue of description breaking due to <script>

### DIFF
--- a/shows/241 - 5 more things.md
+++ b/shows/241 - 5 more things.md
@@ -31,7 +31,7 @@ If you want to know what's happening with your errors, track them with [Sentry](
 
 11:45 - Loading JS asynchronously
 
-* [Where should I put <script> tags in HTML markup?](https://stackoverflow.com/questions/436411/where-should-i-put-script-tags-in-html-markup)
+* [Where should I put script tags in HTML markup?](https://stackoverflow.com/questions/436411/where-should-i-put-script-tags-in-html-markup)
 * Solution: Lazy load JS as needed
 * Solution: Show HTML first, load JS in the footer
 * Solution: Use Async + Defer


### PR DESCRIPTION
The description is set by using dangerouslySetInnerHTML, and as it was encountering only opening <script> tag it is showing an error and stopped parsing. This is causing incomplete description. 
Instead of using <script>, just replaced it with text content script.

The description abruptly stops at - where should I put.

<img width="1111" alt="Screenshot 2020-04-23 at 3 10 47 PM" src="https://user-images.githubusercontent.com/13049676/80084536-9f16e600-8574-11ea-8c6a-8e19092d725d.png">
