### PR TITLE
Revalidate new shows

### DIFF
--- a/lib/getShows.js
+++ b/lib/getShows.js
@@ -39,10 +39,9 @@ const loadShows = async () => {
         html: show.html,
         notesFile: files[i],
         displayDate: format(parseFloat(show.meta.date), 'MMM do, yyyy'),
-        number,
+        displayNumber: pad(show.meta.number),
       };
     }) // flatten
-    .map(show => ({ ...show, displayNumber: pad(show.number) })) // pad zeros
     .reverse();
 
   return shows
@@ -88,6 +87,7 @@ async function getAllShowSickPicks() {
 };
 
 module.exports = {
+  loadShows,
   getShows,
   getShow,
   getAllShowSickPicks

--- a/lib/getShows.js
+++ b/lib/getShows.js
@@ -47,10 +47,10 @@ const loadShows = async () => {
   return shows
 };
 
-async function getShows() {
+async function getShows(filter) {
   const shows = await loadShows()
   const now = Date.now();
-  return shows.filter(show => show.date < now);
+  return filter === 'all' ? shows : shows.filter(show => show.date < now);
 };
 
 async function getShow(number) {

--- a/lib/getShows.js
+++ b/lib/getShows.js
@@ -87,7 +87,6 @@ async function getAllShowSickPicks() {
 };
 
 module.exports = {
-  loadShows,
   getShows,
   getShow,
   getAllShowSickPicks

--- a/pages/show/[number]/[slug].js
+++ b/pages/show/[number]/[slug].js
@@ -39,7 +39,7 @@ export async function getStaticPaths() {
 export async function getStaticProps({params}) {
   const shows = await getShows();
   const showNumber = params.number === 'latest' ? shows[0].displayNumber : params.number;
-  const show = getShow(showNumber);
+  const show = await getShow(showNumber);
   const props = show.date > Date.now() ? {} : { shows, showNumber };
 
   return {

--- a/pages/show/[number]/[slug].js
+++ b/pages/show/[number]/[slug].js
@@ -7,12 +7,12 @@ import ShowNotes from '../../../components/ShowNotes';
 import Player from '../../../components/Player';
 import Meta from '../../../components/meta';
 import Page from '../../../components/Page';
-import { loadShows } from '../../../lib/getShows'
+import { getShows, getShow } from '../../../lib/getShows'
 import slug from 'speakingurl';
 
 
 export async function getStaticPaths() {
-  const shows = await loadShows()
+  const shows = await getShows('all')
 
   return {
     fallback: false,
@@ -37,12 +37,10 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({params}) {
-  const allShows = await loadShows()
-  const now = Date.now()
-  const shows = allShows.filter(show => show.date < now);
-  const showNumber = params.number === 'latest' ? shows[0].displayNumber : params.number
-  const show = allShows.find(showItem => showItem.displayNumber === showNumber)
-  const props = show.date > now ? {} : { shows, showNumber }
+  const shows = await getShows();
+  const showNumber = params.number === 'latest' ? shows[0].displayNumber : params.number;
+  const show = getShow(showNumber);
+  const props = show.date > Date.now() ? {} : { shows, showNumber };
 
   return {
     unstable_revalidate: 1,

--- a/shows/262 - react wish list.md
+++ b/shows/262 - react wish list.md
@@ -21,12 +21,12 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 
 06:20 - Suspense with SSR released (or not because I think they are shelving it)
 
-* Dan's tweet: [https://twitter.com/dan_abramov/status/1259614150386425858](https://twitter.com/dan_abramov/status/1259614150386425858) 
+* Dan's tweet: [https://twitter.com/dan_abramov/status/1259614150386425858](https://twitter.com/dan_abramov/status/1259614150386425858)
 
 09:24 - File based components
 
 * Like Svelte and Vue
-* This would look like a file with a special scoped <style> tag per page. 
+* This would look like a file with a special scoped `<style>` tag per page.
 
 11:50 - Prevent Default shortcuts
 
@@ -42,7 +42,7 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 
 18:25 - A good form strategy
 
-* Bind inputs to state directly without any change handlers 
+* Bind inputs to state directly without any change handlers
 * Inputs and forms all around need more magic - it's painful
 
 20:43 - Write once deploy everywhere
@@ -52,7 +52,7 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 
 22:28 - Compile time directives
 
-* [https://github.com/bukharim96/directive-x](https://github.com/bukharim96/directive-x) 
+* [https://github.com/bukharim96/directive-x](https://github.com/bukharim96/directive-x)
 
 25:11 - Slots instead of children
 
@@ -100,7 +100,7 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 * [NativeScript](https://nativescript.org/)
 * [react-spring](https://www.react-spring.io/)
 * [Paul Henschel](https://twitter.com/0xca0a)
-* Scream Sneeze: [https://twitter.com/morganc_smith/status/1235332301044801538](https://twitter.com/morganc_smith/status/1235332301044801538) 
+* Scream Sneeze: [https://twitter.com/morganc_smith/status/1235332301044801538](https://twitter.com/morganc_smith/status/1235332301044801538)
 
 ## ××× SIIIIICK ××× PIIIICKS ×××
 * Scott: [Software Engineering Daily Podcast](https://softwareengineeringdaily.com/)


### PR DESCRIPTION
The shows are now filtered inside `getStaticProps` instead of `getStaticPaths`, allowing not released shows to be revalidated.

Also did a change to the upcoming show to make sure it doesn't output invalid HTML.