### PR TITLE
Fix - Update Broken Edit Show Links

### DIFF
--- a/lib/getShows.js
+++ b/lib/getShows.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const { promisify } = require('util');
 const glob = promisify(require('glob'));
 const marked = require('meta-marked');
@@ -23,8 +22,7 @@ const loadShows = async () => {
     return shows
   }
 
-  const showsPath = path.resolve(process.cwd(), 'shows');
-  const files = await glob(path.join(showsPath, '*.md'));
+  const files = await glob('shows/*.md');
   const markdownPromises = files.map(file => readAFile(file, 'utf-8'));
   const showMarkdown = await Promise.all(markdownPromises);
 


### PR DESCRIPTION
The `Edit Show Notes` links are leading to GitHub 404 pages. This is related to using `process.cwd()`.  I'm not sure of the intended purpose of the commit this PR reverts, but this should get things back into working order. 👍 

**Current Prod URL:** https://github.com/wesbos/Syntax/edit/master//var/task/shows/271%20-%20upgrading.md

**Local URL Example:** https://github.com/wesbos/Syntax/edit/master//Users/ryan/Desktop/Syntax/shows/271%20-%20upgrading.md

**Working URL:** https://github.com/wesbos/Syntax/edit/master/shows/271%20-%20upgrading.md