### PR TITLE
fix: edit show notes link issues

### DIFF
--- a/lib/getShows.js
+++ b/lib/getShows.js
@@ -23,7 +23,7 @@ const loadShows = async () => {
     return shows
   }
 
-  const showsPath = path.resolve(process.cwd(), 'shows');
+  const showsPath = 'shows';
   const files = await glob(path.join(showsPath, '*.md'));
   const markdownPromises = files.map(file => readAFile(file, 'utf-8'));
   const showMarkdown = await Promise.all(markdownPromises);


### PR DESCRIPTION
Issue : On clicking Edit Show Notes button, it doesn't redirect to the edit page.

More precisely,

**Before:**

![before](https://user-images.githubusercontent.com/50266088/91055716-c249c300-e644-11ea-813b-99c23936fe23.gif)

**Now**
![now](https://user-images.githubusercontent.com/50266088/91055773-d55c9300-e644-11ea-95f5-c200a014deeb.gif)


