### PR TITLE
Fixes query parameters error

### DIFF
--- a/pages/show/[number]/[slug].js
+++ b/pages/show/[number]/[slug].js
@@ -58,7 +58,6 @@ export default withRouter(
     constructor(props) {
       super();
       const currentShow = props.showNumber
-
       this.state = {
         currentShow,
         currentPlaying: currentShow,
@@ -68,7 +67,7 @@ export default withRouter(
 
     componentWillReceiveProps(nextProps) {
       const { query } = nextProps.router;
-      if (query.number) {
+      if (query.number && query.number !== 'latest') {
         this.setState({ currentShow: query.number });
       }
     }


### PR DESCRIPTION
fixes: https://github.com/wesbos/Syntax/issues/528

To reproduce error on master in dev, you can try loading `localhost:3000/?test=test` or any query parameter and it breaks the app
Or in prod right now: syntax.fm/?utm_param=test 

3rd party sites will append url params to links posted so this is an issue if someone is trying to access the site from a link from Facebook or somewhere else