### PR TITLE
Update show notes link to Angular

### DIFF
--- a/shows/290 - potluck.md
+++ b/shows/290 - potluck.md
@@ -70,7 +70,7 @@ export class MyComponent {
 * [8 Mile](https://www.imdb.com/title/tt0298203/)
 * [Syntax 286: Git Fundamentals](https://syntax.fm/show/286/git-fundamentals)
 * [Rev](https://www.rev.com/)
-* [Angular](https://angularjs.org/)
+* [Angular](https://angular.io/)
 * [React](https://reactjs.org/)
 * [Svelte](https://svelte.dev/)
 * [SVGR](https://react-svgr.com/)


### PR DESCRIPTION
I would like to propose updating the link to Angular from the old v1 AngularJS
site to the new v10 Angular site (angular.io) in the show notes for episode 290.