### PR TITLE
fix: update show notes edit url

### DIFF
--- a/components/ShowNotes.js
+++ b/components/ShowNotes.js
@@ -23,7 +23,7 @@ const ShowNotes = ({ show, setCurrentPlaying }) => {
       </a>
       <a
         className="button"
-        href={`https://github.com/wesbos/Syntax/edit/master/${show.notesFile}`}
+        href={`https://github.com/wesbos/Syntax/edit/master/shows/${show.notesFile}`}
         target="_blank"
         rel="noopener noreferrer"
       >


### PR DESCRIPTION
### Description
This updates the show notes edit url to redirect to the edit page on GitHub.

### Problem/Solution
The link for the `Edit Show Notes` had a stale URL, this PR updates it to have the `/shows` in the path to fix it.

### Steps to reproduce
Go to the Vercel deploy preview (https://syntax-git-fix-show-notes-url.wesbos.vercel.app) and click on `Edit Show Notes` under an episode show, you should be redirected to the edit page on GitHub instead of a 404.

### Screencast
![syntax_notes_bug](https://user-images.githubusercontent.com/3136873/96897304-13631100-1454-11eb-849c-98bca16972c5.gif)

### Context
https://twitter.com/syntaxfm/status/1319040265882116099