### PR TITLE
fix: update show notes link (ep306)

### DIFF
--- a/shows/306 - gift guide.md
+++ b/shows/306 - gift guide.md
@@ -36,7 +36,7 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 
 17:16 - Tech
 * Headphones
-  * Sony WH1000XM4 - [https://amzn.to/2Ube8c8](https://amzn.to/2Ube8c8)
+  * Sony WH1000XM4 - [https://amzn.to/37yb1Bm](https://amzn.to/37yb1Bm)
   * Bose QC35 - [https://amzn.to/3lrKrQp](https://amzn.to/3lrKrQp)
   * Wyze Noise-Cancelling Headphones - [https://wyze.com/wyze-headphones.html](https://wyze.com/wyze-headphones.html)
 * USB-C Hub - [https://amzn.to/3keljem](https://amzn.to/3keljem)


### PR DESCRIPTION
Fixed the Amazon link of Sony WH1000XM4  which was wrongly linked to Vivo Pneumatic Mic Arm.

Shamelessly changed it to my affiliate link but feel free to fix it to yours.

Anyways, Merry Christmas!! 🎄