### PR TITLE
fix: :iphone: moved margin to align on smaller screens

### DIFF
--- a/styles/_button.styl
+++ b/styles/_button.styl
@@ -8,10 +8,9 @@
   padding 1rem
   display inline-block
   transition all 0.2s
+  margin-right 1rem
   &:hover
     background darken(lightgrey, 3%)
-  & + .button
-    margin-left 1rem
   .icon
     border-right 1px solid grey
     padding-right 0.5rem


### PR DESCRIPTION
Moved margin to right side - simplified _button.styl and fixed alignment on narrower screens (mobile or narrow desktop views)

### Before
Buttons in `ShowNotes` component were misaligned in narrower screens due to left margin. 

<img width="925" alt="syntax fm-wide-markedup" src="https://user-images.githubusercontent.com/3733140/109429907-0aff8180-79c4-11eb-8216-db8c023a8dcd.png">
<img width="375" alt="syntax fm-narrow-markedup" src="https://user-images.githubusercontent.com/3733140/109429908-0d61db80-79c4-11eb-85a1-31ea01430304.png">


### After
Margin moved to right side to allow for simpler .styl file and proper alignment in narrow/mobile views
<img width="1115" alt="Screen Shot 2021-02-28 at 12 56 21" src="https://user-images.githubusercontent.com/3733140/109447282-f396b780-7a08-11eb-9dfd-6b9606ea4fb1.png">
<img width="339" alt="Screen Shot 2021-02-28 at 21 05 57" src="https://user-images.githubusercontent.com/3733140/109447287-f5607b00-7a08-11eb-8e32-233ab10b055b.png">
