### PR TITLE
fix: removed font-weight: 100 from header links

### DIFF
--- a/styles/_header.styl
+++ b/styles/_header.styl
@@ -86,7 +86,6 @@
       text-align center
       border-radius 3px
       font-family sans-serif
-      font-weight 100
       transition all 0.2s
       display flex
       align-items center


### PR DESCRIPTION
On Firefox Linux header links were a bit off:
![image](https://user-images.githubusercontent.com/3428837/114412175-2528a400-9bad-11eb-8ae8-f3dbf9bb0353.png)

Apparently the `font-weight: 100` was not handled as in Chrome. Anyway removing it looks good in Chrome, Chromium and Firefox:
![image](https://user-images.githubusercontent.com/3428837/114412435-628d3180-9bad-11eb-8f61-0480cf72504b.png)
