### PR TITLE
Updated episode number to 520 instead of 484

### DIFF
--- a/shows/520 - Supper with Nikolas Burke.md
+++ b/shows/520 - Supper with Nikolas Burke.md
@@ -1,5 +1,5 @@
 ---
-number: 484
+number: 520
 title: Supper Club × ORMs with Nikolas Burke from Prisma
 date: 1665144000037
 url: https://traffic.libsyn.com/syntax/Syntax_-_520.mp3


### PR DESCRIPTION
Fixes: #818

Episode 520 has `number: 484` in the frontmatter, and causes issues with playback of the original episode 484.

After changing the number to 520, and recompiling the site, I was able to play both episodes on my local machine (see screenshots of the before/after below).

Before:
![image](https://user-images.githubusercontent.com/50255197/195707684-1d727a74-d057-40e2-83fa-a5df6536be1f.png)

After:
![image](https://user-images.githubusercontent.com/50255197/195707464-63319ad0-d2de-4ba9-a83b-820ca63efc14.png)

