### PR TITLE
Update package.json node engines to latest LTS version (node 18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "syntax",
   "description": "Full Stack Developers Wes Bos and Scott Tolinski dive deep into web development topics, explaining how they work and talking about their own experiences. They cover from JavaScript frameworks like React, to the latest advancements in CSS to simplifying web tooling.",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "dev": "next dev --port 6969",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "syntax",
   "description": "Full Stack Developers Wes Bos and Scott Tolinski dive deep into web development topics, explaining how they work and talking about their own experiences. They cover from JavaScript frameworks like React, to the latest advancements in CSS to simplifying web tooling.",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "scripts": {
     "dev": "next dev --port 6969",


### PR DESCRIPTION
Tools that autodetect node versions (like nixpacks on @flightcontrolhq) use the package.json field to choose which node version to use. Node 14 is very old and npm install fails with it.

This updates engines field to use v18 which is the current node LTS version.