### PR TITLE
Fix link to statcounter in Episode 911

### DIFF
--- a/shows/911 - Browsers in 2025 Whats up with Arc Dia Firefox Chrome and Opera GX.md
+++ b/shows/911 - Browsers in 2025 Whats up with Arc Dia Firefox Chrome and Opera GX.md
@@ -10,33 +10,33 @@ Scott and Wes break down the state of web browsers in 2025, from the rise and fa
 
 ### Show Notes
 
-* **[00:00](#t=00:00)** Welcome to Syntax!
-* **[01:37](#t=01:37)** Rendering Engines.
-* **[02:11](#t=02:11)** Arc Browser.
-* **[02:41](#t=02:41)** Microsoft Edge.
-* **[03:45](#t=03:45)** Why not Brave?
-* **[05:25](#t=05:25)** Brought to you by [Sentry.io](https://sentry.io/syntax).
-* **[05:50](#t=05:50)** Google Manifest v2.
-* **[07:32](#t=07:32)** Opera.
-  * [OperaGX](https://www.opera.com/gx).
-* **[10:13](#t=10:13)** [Vivaldi](https://vivaldi.com/).
-* **[11:23](#t=11:23)** The death of [Arc](https://arc.net/) Browser.
-  * **[11:44](#t=11:44)** [Dia](https://www.diabrowser.com/)?
-  * **[14:43](#t=14:43)** No revenue from power-users.
-  * [Letter to Arc Members](https://browsercompany.substack.com/p/letter-to-arc-members-2025).
-  * **[15:38](#t=15:38)** Arc's transition to a new browser.
-  * **[17:02](#t=17:02)** Browser companies need to lock users fast!
-* **[19:42](#t=19:42)** Gecko.
-  * **[19:45](#t=19:45)** Firefox.
-  * **[21:08](#t=21:08)** [Zen](https://zen-browser.app/).
-* **[22:38](#t=22:38)** Webkit.
-  * [There Still Arent Any iPhone Browsers With Custom Engines](https://tech.yahoo.com/phones/articles/still-arent-iphone-browsers-custom-151159611.html)
-* **[29:18](#t=29:18)** Wtf is [Ladybird](https://ladybird.org/)?
-* **[34:14](#t=34:14)** Usage statistics.
-  * [StatCounter.com](https://www.statcounter.com).
-* **[39:32](#t=39:32)** Dev Tools experience ranked.
-* **[42:06](#t=42:06)** Tab experience.
-* **[43:37](#t=43:37)** Containers and profiles.
+- **[00:00](#t=00:00)** Welcome to Syntax!
+- **[01:37](#t=01:37)** Rendering Engines.
+- **[02:11](#t=02:11)** Arc Browser.
+- **[02:41](#t=02:41)** Microsoft Edge.
+- **[03:45](#t=03:45)** Why not Brave?
+- **[05:25](#t=05:25)** Brought to you by [Sentry.io](https://sentry.io/syntax).
+- **[05:50](#t=05:50)** Google Manifest v2.
+- **[07:32](#t=07:32)** Opera.
+  - [OperaGX](https://www.opera.com/gx).
+- **[10:13](#t=10:13)** [Vivaldi](https://vivaldi.com/).
+- **[11:23](#t=11:23)** The death of [Arc](https://arc.net/) Browser.
+  - **[11:44](#t=11:44)** [Dia](https://www.diabrowser.com/)?
+  - **[14:43](#t=14:43)** No revenue from power-users.
+  - [Letter to Arc Members](https://browsercompany.substack.com/p/letter-to-arc-members-2025).
+  - **[15:38](#t=15:38)** Arc's transition to a new browser.
+  - **[17:02](#t=17:02)** Browser companies need to lock users fast!
+- **[19:42](#t=19:42)** Gecko.
+  - **[19:45](#t=19:45)** Firefox.
+  - **[21:08](#t=21:08)** [Zen](https://zen-browser.app/).
+- **[22:38](#t=22:38)** Webkit.
+  - [There Still Arent Any iPhone Browsers With Custom Engines](https://tech.yahoo.com/phones/articles/still-arent-iphone-browsers-custom-151159611.html)
+- **[29:18](#t=29:18)** Wtf is [Ladybird](https://ladybird.org/)?
+- **[34:14](#t=34:14)** Usage statistics.
+  - [StatCounter.com](https://www.statcounter.com).
+- **[39:32](#t=39:32)** Dev Tools experience ranked.
+- **[42:06](#t=42:06)** Tab experience.
+- **[43:37](#t=43:37)** Containers and profiles.
 
 ### Hit us up on Socials!
 


### PR DESCRIPTION
This pull request makes a minor correction to a hyperlink in [Episode 911](https://syntax.fm/show/911/browsers-in-2025-whats-up-with-arc-dia-firefox-chrome-and-opera-gx). The change updates the `StatCounter.com` link to include `https://` which fixes the link from going to https://syntax.fm/show/911/www.statcounter.com to https://www.statcounter.com.