### PR TITLE
Fix non-breaking spaces in show 991 YAML frontmatter

### DIFF
--- a/shows/991 - Vites bet on Cloudflare VOID Framework.md
+++ b/shows/991 - Vites bet on Cloudflare VOID Framework.md
@@ -5,9 +5,9 @@ date: 1774868400000
 url: https://traffic.megaphone.fm/FSI5967497459.mp3
 youtube_url: https://www.youtube.com/watch?v=wtkZUdkUHhc
 hosts:
-  - stolinski
-  - wesbos
-  - w3cj
+  - stolinski
+  - wesbos
+  - w3cj
 ---
 	
 Vite just launched Void, a fullstack JavaScript framework and cloud platform that bundles together routing, SSR, auth, an ORM, and nearly everything you'd expect from a modern meta-framework — all built on top of Cloudflare's infrastructure. Scott, Wes, and CJ dig into whether Void is the Rails moment JavaScript has been waiting for, or just shiny Cloudflare lock-in with a bow on it.


### PR DESCRIPTION
## Summary

- The `hosts` list in show 991's frontmatter was indented with non-breaking spaces (U+00A0) instead of regular ASCII spaces
- YAML parsers don't treat U+00A0 as whitespace, causing the parse error: `could not find expected ':' while scanning a simple key at line 7 column 1`
- This likely prevented the show from being imported into the DB correctly

## Fix

Replaced 6 non-breaking spaces with regular spaces in the `hosts` block indentation.

Relates to #2177

<img width="1193" height="627" alt="image" src="https://github.com/user-attachments/assets/1d76a10f-f9c4-4522-825e-bbc462dc53e0" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)