### PR TITLE
Add frontmatter validation for non-breaking spaces

### DIFF
--- a/scripts/merging-show-validation.js
+++ b/scripts/merging-show-validation.js
@@ -95,6 +95,19 @@ const validateTimestamps = (content) => {
 	return invalidTimestamps;
 };
 
+// Function to check frontmatter for invalid whitespace characters
+const validateFrontmatter = (content) => {
+	const frontMatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+	if (!frontMatterMatch) return [];
+
+	const errors = [];
+	const frontMatter = frontMatterMatch[1];
+	if (frontMatter.includes('\u00A0')) {
+		errors.push('non-breaking space (U+00A0) found in frontmatter — use regular spaces for indentation');
+	}
+	return errors;
+};
+
 // Function to process a single markdown file for broken links
 const processFile = async (filePath) => {
 	const content = await fs.readFile(filePath, 'utf8');
@@ -115,10 +128,12 @@ const processFile = async (filePath) => {
 	const brokenLinks = urlsToCheck.filter((_, index) => !results[index]);
 
 	const invalidTimestamps = validateTimestamps(content);
+	const frontmatterErrors = validateFrontmatter(content);
 
 	return {
 		brokenLinks,
-		invalidTimestamps
+		invalidTimestamps,
+		frontmatterErrors
 	};
 };
 
@@ -149,13 +164,14 @@ const main = async () => {
 		console.log('No new markdown files to check in ./shows.');
 	} else {
 		for (const file of mdFiles) {
-			const { brokenLinks, invalidTimestamps } = await processFile(file);
-			if (brokenLinks.length > 0 || invalidTimestamps.length > 0) {
+			const { brokenLinks, invalidTimestamps, frontmatterErrors } = await processFile(file);
+			if (brokenLinks.length > 0 || invalidTimestamps.length > 0 || frontmatterErrors.length > 0) {
 				errorMessages.push(`Issues found in ${file}:`);
 				brokenLinks.forEach((link) => errorMessages.push(`- Broken link: ${link}`));
 				invalidTimestamps.forEach((timestamp) =>
 					errorMessages.push(`- Invalid timestamp: ${timestamp}`)
 				);
+				frontmatterErrors.forEach((err) => errorMessages.push(`- Invalid frontmatter: ${err}`));
 			}
 		}
 	}

--- a/shows/991 - Vites bet on Cloudflare VOID Framework.md
+++ b/shows/991 - Vites bet on Cloudflare VOID Framework.md
@@ -5,9 +5,9 @@ date: 1774868400000
 url: https://traffic.megaphone.fm/FSI5967497459.mp3
 youtube_url: https://www.youtube.com/watch?v=wtkZUdkUHhc
 hosts:
-  - stolinski
-  - wesbos
-  - w3cj
+  - stolinski
+  - wesbos
+  - w3cj
 ---
 	
 Vite just launched Void, a fullstack JavaScript framework and cloud platform that bundles together routing, SSR, auth, an ORM, and nearly everything you'd expect from a modern meta-framework — all built on top of Cloudflare's infrastructure. Scott, Wes, and CJ dig into whether Void is the Rails moment JavaScript has been waiting for, or just shiny Cloudflare lock-in with a bow on it.


### PR DESCRIPTION
## Summary

- Adds a `validateFrontmatter` check to `scripts/merging-show-validation.js`
- Detects non-breaking spaces (U+00A0) used as indentation in show frontmatter YAML
- Fails CI with a clear error message before the PR can be merged

This prevents a repeat of the issue in #2179 where show 991's `hosts` list was indented with non-breaking spaces, breaking YAML parsing and likely preventing the show from being imported into the DB.

Closes #2177

🤖 Generated with [Claude Code](https://claude.com/claude-code)