### PR TITLE
fix: correct 42 typos in show notes

### DIFF
--- a/shows/035 - Keeping Up.md
+++ b/shows/035 - Keeping Up.md
@@ -72,7 +72,7 @@ If you are a small business or freelancer check out [Freshbooks.com Cloud Accoun
 
 30:00
 
-* Complacency in Web Devleopment
+* Complacency in Web Development
 * Motivating Comfortable Web Developers
 * You have to stay up to date
 

--- a/shows/039 - Is jQuery Dead.md
+++ b/shows/039 - Is jQuery Dead.md
@@ -67,7 +67,7 @@ If you are a small business or freelancer check out [Freshbooks.com Cloud Accoun
 
 34:00
 
-* Cross Browser Compatability
+* Cross Browser Compatibility
 * [Polyfill.io](https://Polyfill.io)
 
 37:00

--- a/shows/047 - How to Get Better at Debugging.md
+++ b/shows/047 - How to Get Better at Debugging.md
@@ -47,7 +47,7 @@ Check out Coffeecup's [CSS Grid.cc](https://cssgrid.cc/) builder tool and resour
 
 17:02
 
-* View your code in other browers
+* View your code in other browsers
 * Make sure your browser is up to date
 
 18:50
@@ -91,7 +91,7 @@ Check out Coffeecup's [CSS Grid.cc](https://cssgrid.cc/) builder tool and resour
 32:34 - Chrome Dev Tools Tabs Rundown
 
 * 33:10 - Network tab
-* 34:15 - Preformance tab
+* 34:15 - Performance tab
 * 35:58 - Lesser known tools
   * 36:15 - Firefox Grid Debug
   * 36:20 - Firefox Fonts tab

--- a/shows/097 - CSS Variables.md
+++ b/shows/097 - CSS Variables.md
@@ -18,7 +18,7 @@ Kyle Prinsloo teaches you everything you need to know about freelancing, includi
 - `--example-name`, represent custom properties
 - called using `var()`
 - Overwrite with a more specific style
-- Use JavaScript to append .style.setPropert(
+- Use JavaScript to append .style.setProperty(
 
 - How are they scoped?
   - Just like normal CSS

--- a/shows/098 - State of Javascript.md
+++ b/shows/098 - State of Javascript.md
@@ -4,14 +4,14 @@ title: The State of JavaScript 2018
 date: 1544018400079
 url: https://traffic.megaphone.fm/FSI5054559403.mp3
 guest:
-  name: Sacha Greif
+  name: Sacha Grief
   of: State of JS Survey
   github: sachag
-  twitter: SachaGreif
+  twitter: SachaGrief
   url: https://sachagreif.com/
 ---
 
-In this episode Wes and Scott are joined by their first ever guest on the show: Sacha Greif. Sacha is one of the makers of the [State of Javascript](https://stateofjs.com/) - the topic for today's show. Wes, Scott and Sacha discuss the results of 2018's survey, what they think, and implications for the industry.
+In this episode Wes and Scott are joined by their first ever guest on the show: Sacha Grief. Sacha is one of the makers of the [State of Javascript](https://stateofjs.com/) - the topic for today's show. Wes, Scott and Sacha discuss the results of 2018's survey, what they think, and implications for the industry.
 
 ## Sentry - Sponsor
 
@@ -23,7 +23,7 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 
 ## Guests
 
-* [Sacha Greif](https://twitter.com/SachaGreif)
+* [Sacha Grief](https://twitter.com/SachaGrief)
 
 ## Show Notes
 

--- a/shows/098 - State of Javascript.md
+++ b/shows/098 - State of Javascript.md
@@ -4,14 +4,14 @@ title: The State of JavaScript 2018
 date: 1544018400079
 url: https://traffic.megaphone.fm/FSI5054559403.mp3
 guest:
-  name: Sacha Grief
+  name: Sacha Greif
   of: State of JS Survey
   github: sachag
-  twitter: SachaGrief
+  twitter: SachaGreif
   url: https://sachagreif.com/
 ---
 
-In this episode Wes and Scott are joined by their first ever guest on the show: Sacha Grief. Sacha is one of the makers of the [State of Javascript](https://stateofjs.com/) - the topic for today's show. Wes, Scott and Sacha discuss the results of 2018's survey, what they think, and implications for the industry.
+In this episode Wes and Scott are joined by their first ever guest on the show: Sacha Greif. Sacha is one of the makers of the [State of Javascript](https://stateofjs.com/) - the topic for today's show. Wes, Scott and Sacha discuss the results of 2018's survey, what they think, and implications for the industry.
 
 ## Sentry - Sponsor
 
@@ -23,7 +23,7 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 
 ## Guests
 
-* [Sacha Grief](https://twitter.com/SachaGrief)
+* [Sacha Greif](https://twitter.com/SachaGreif)
 
 ## Show Notes
 

--- a/shows/103 - where are they now part 2.md
+++ b/shows/103 - where are they now part 2.md
@@ -36,9 +36,9 @@ Sanity.io is a real-time headless CMS with a fully customizable Content Studio b
 * [Bootstrap](https://getbootstrap.com/)
 * [Foundation](https://foundation.zurb.com/)
 
-16:02 - CoffeScript
+16:02 - CoffeeScript
 
-* [CoffeScript](https://coffeescript.org/)
+* [CoffeeScript](https://coffeescript.org/)
 * [Compass](http://compass-style.org/)
 
 18:18 - Underscore.js

--- a/shows/236 - mental.md
+++ b/shows/236 - mental.md
@@ -78,7 +78,7 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 
 ## Shameless Plugs
 * Scott: [All Courses](https://www.leveluptutorials.com/pro) - Sign up for the year and save 50%!
-* Wes: [All Courses](https://wesbos.com/courses/) - Eveything is 50% off! Use the coupon code 'Syntax' for $10 off!
+* Wes: [All Courses](https://wesbos.com/courses/) - Everything is 50% off! Use the coupon code 'Syntax' for $10 off!
 
 ## Tweet us your tasty treats!
 * [Scott's Instagram](https://www.instagram.com/stolinski/)

--- a/shows/248 - new in JS.md
+++ b/shows/248 - new in JS.md
@@ -40,7 +40,7 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 30:44 - Module Namespace Exports
 33:11 - Navigator.share() API
 36:34 - Async Hooks
-37:39 - Pipline Operator 
+37:39 - Pipeline Operator 
 39:59 - Top Level Await 
 
 ## Links

--- a/shows/294 - spooky.md
+++ b/shows/294 - spooky.md
@@ -39,7 +39,7 @@ If you want to know what's happening with your errors, track them with [Sentry](
 
 23:06 - WordPress Plugins
 
-23:52 - Loggin Ya In, Ya F'in Dummy
+23:52 - Logging Ya In, Ya F'in Dummy
 
 24:58 - A Hostel Coding Environment
 

--- a/shows/384 - stumped.md
+++ b/shows/384 - stumped.md
@@ -36,7 +36,7 @@ Auth0 is the easiest way for developers to add authentication and secure their a
 
 23:33 - What is the use of preventDefault method?
 
-26:15 - What is a spread opperator?
+26:15 - What is a spread operator?
 
 27:35 - What is the output of below spread operator array?
 * `[...'John Resig']`

--- a/shows/387 - starlink.md
+++ b/shows/387 - starlink.md
@@ -19,7 +19,7 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 * Remote work
   * Opens up job opportunities for many residents who can't relocate due to family
 * Home values
-  * Big city folk moving into rural areas and driving prices up is another issue alltogether
+  * Big city folk moving into rural areas and driving prices up is another issue altogether
 * Smart rural home
 
 05:46 - Previous setup

--- a/shows/388 - ES2022.md
+++ b/shows/388 - ES2022.md
@@ -17,10 +17,10 @@ LogRocket lets you replay what users do on your site, helping you reproduce bugs
 Auth0 is the easiest way for developers to add authentication and secure their applications. They provides features like user management, multi-factor authentication, and you can even enable users to login with device biometrics with something like their fingerprint. Not to mention, Auth0 has SDKs for your favorite frameworks like React, Next.js, and Node/Express. Make sure to sign up for a free account and give Auth0 a try with the link below: [https://a0.to/syntax](https://a0.to/syntax).
 
 ## Show Notes
-04:50 - Regex indicies
+04:50 - Regex indices
 * New `d` flag in a regex
 * [https://regex101.com/](https://regex101.com/)
-* This will tell you the indexes (indicies) of the regex matches
+* This will tell you the indexes (indices) of the regex matches
 * Handy if you need to highlight or replaces matches in a string
 * We can ask for the start and end positions of each matched capture group
 
@@ -29,7 +29,7 @@ Auth0 is the easiest way for developers to add authentication and secure their a
 * Properties and Methods to be kept private 
 * Prefix them with a `#` 
 * =Helpful for internal state and methods which should not be accessed directly or at all by external 
-* In React how we have ___INTERNTAL_NEVER USE THIS_
+* In React how we have ___INTERNAL_NEVER USE THIS_
 
 ```jsx
 

--- a/shows/390 - sveltekit.md
+++ b/shows/390 - sveltekit.md
@@ -31,7 +31,7 @@ If you want to know what’s happening with your code, track errors and monitor 
 16:14 - Converting React components to Svelte
 * useState becomes just a straight-up variable
 * Graphql calls were hooks now just imported generated functions
-* Remove extranous fragments
+* Remove extraneous fragments
 * Convert {things && } to {#if thing}{/if}
 * `<component hello={hello} />` becomes `<component {hello} />`
 

--- a/shows/409 - Github Co-pilot is Gonna Take ur Job.md
+++ b/shows/409 - Github Co-pilot is Gonna Take ur Job.md
@@ -27,7 +27,7 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 * **[09:43](#t=09:43)** Writing pseudo code
 * [Emmet](https://www.emmet.io)
 * **[12:51](#t=12:51)** Using it for loop callbacks
-* **[13:52](#t=13:52)** What langauges does GitHub Co-Pilot work with?
+* **[13:52](#t=13:52)** What languages does GitHub Co-Pilot work with?
 * **[14:54](#t=14:54)** It plays nice with HTML files
 * **[15:48](#t=15:48)** Svelte component example
 * **[16:31](#t=16:31)** Benefits for course creators

--- a/shows/419 - JS One Liners.md
+++ b/shows/419 - JS One Liners.md
@@ -22,7 +22,7 @@ If you want to know what’s happening with your code, track errors and monitor 
 * **[02:11:02](#t=02:11:02)** Sponsor: Sentry
 * **[03:54:18](#t=03:54:18)** Twitter ask for One Liners
 * **[04:24:05](#t=04:24:05)** Math random
-`const getPsuedoID =() => Math.floor(Math.random() * 1e15);`
+`const getPseudoID =() => Math.floor(Math.random() * 1e15);`
 * **[05:43:09](#t=05:43:09)** Random color
 * [Paul Irish random color](https://www.paulirish.com/2009/random-hex-color-code-snippets/)
 `'#'+Math.floor(Math.random()*16777215).toString(16);`

--- a/shows/430 - Creator of Wordle.md
+++ b/shows/430 - Creator of Wordle.md
@@ -34,7 +34,7 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 * **[07:07:06](#t=07:07:06)** What's your background?
 * [Reddit.com](https://www.reddit.com)
 * **[12:52:23](#t=12:52:23)** Writing just HTML CSS and JavaScript
-* **[15:58:24](#t=15:58:24)** Wordle has 2 external dependancies
+* **[15:58:24](#t=15:58:24)** Wordle has 2 external dependencies
 * **[16:41:06](#t=16:41:06)** Sponsor: Sentry
 * **[17:40:23](#t=17:40:23)** The tech stack of Wordle
 * [Lit Elements](https://lit.dev)

--- a/shows/450 - potluck.md
+++ b/shows/450 - potluck.md
@@ -40,7 +40,7 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 * [Syntax 346 - Selling T Shirts](https://syntax.fm/show/346/selling-and-shipping-t-shirts-with-typescript)
 * **[29:15](#t=29:15)** Sponsor: Sanity.io
 * **[30:47](#t=30:47)** Since NextJS has API routes, could you build a full-stack application using just NextJS?
-* **[35:41](#t=35:41)** Do you keep your landing pages and home pages seperate from your app?
+* **[35:41](#t=35:41)** Do you keep your landing pages and home pages separate from your app?
 * **[37:35](#t=37:35)** Where's the line for moving something hosted on a developer server to moving it to production?
 * [CodePen](https://codepen.io)
 * [Replit](https://replit.com)

--- a/shows/459 - Potluck.md
+++ b/shows/459 - Potluck.md
@@ -28,7 +28,7 @@ Auth0 is the easiest way for developers to add authentication and secure their a
 * **[09:09](#t=09:09)** Why does my M1 Mac feel slower than my Intel Mac?
 * **[14:44](#t=14:44)** Do you alphabetize your larger javascript objects by key name?
 * **[17:14](#t=17:14)** Sponsor: Prismic
-* **[19:06](#t=19:06)** Why did you choose noSQL database over SQL databse?
+* **[19:06](#t=19:06)** Why did you choose noSQL database over SQL database?
 * **[25:13](#t=25:13)** What does it mean to support ESM?
 * **[30:23](#t=30:23)** Sponsor: LogRocket
 * **[31:35](#t=31:35)** Are open source maintainers doing harm by inserting protestware into packages?

--- a/shows/468 - Syntax Live at Reactathon.md
+++ b/shows/468 - Syntax Live at Reactathon.md
@@ -32,7 +32,7 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 * **[08:11](#t=08:11)** Sponsor: Sentry
 * **[09:23](#t=09:23)** A good website should function without JavaScript
 * **[10:28](#t=10:28)** Classes were a mistake
-* **[10:54](#t=10:54)** Stay as close to the platform primatives
+* **[10:54](#t=10:54)** Stay as close to the platform primitives
 * **[11:36](#t=11:36)** TypeScript is overrated and overhyped
 * **[11:50](#t=11:50)** Kickin it old school
 * [PNG Fix](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/7eaa615a-4f84-4f56-9183-552cac4a5609/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20220606%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220606T214149Z&X-Amz-Expires=86400&X-Amz-Signature=2fa8be31a737a4a682db588382392c610b9ebb0b55036c977ffb6ae7a97d6356&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22Untitled.png%22&x-id=GetObject)

--- a/shows/479 - CSS5.md
+++ b/shows/479 - CSS5.md
@@ -19,7 +19,7 @@ Whether you’re working on a personal project or managing enterprise infrastruc
 * **[05:13](#t=05:13)** New CSS Color mix function
 * **[10:29](#t=10:29)** Color for the color challenged
 * **[12:53](#t=12:53)** Color contrast function
-* **[15:06](#t=15:06)** Programatically alter colors
+* **[15:06](#t=15:06)** Programmatically alter colors
 
 * [Anyone have a really great CSS Variables color system strategy?](https://twitter.com/stolinski/status/1516877461539143680)
 * [Color for the color challenged](https://ferdychristant.com/color-for-the-color-challenged-884c7aa04a56)

--- a/shows/494 - Hasty Browsers and engines.md
+++ b/shows/494 - Hasty Browsers and engines.md
@@ -5,7 +5,7 @@ date: 1659960000726
 url: https://traffic.megaphone.fm/FSI8578730387.mp3
 ---
 
-In this Hasty Treat, Scott and Wes talk about the various web browers that might show up in your analytics and whether you need to worry about supporting them or not.
+In this Hasty Treat, Scott and Wes talk about the various web browsers that might show up in your analytics and whether you need to worry about supporting them or not.
 
 ## Sentry - Sponsor
 

--- a/shows/523 - Supper.md
+++ b/shows/523 - Supper.md
@@ -42,7 +42,7 @@ Today’s episode was sponsored by Gatsby, the fastest frontend for the headless
 - **[06:14](#t=06:14)** Why did you choose to write in Lua?
 - [Lua](https://www.lua.org)
 - [Luajit](http://luajit.org/luajit.html)
-- **[13:26](#t=13:26)** What is adapative UI in Neovim?
+- **[13:26](#t=13:26)** What is adaptive UI in Neovim?
 - **[17:38](#t=17:38)** Lunarvim and alternatives
 - [Fvim](https://github.com/yatli/fvim)
 - [LunarVim](https://www.lunarvim.org)

--- a/shows/525 - HTTP Archive.md
+++ b/shows/525 - HTTP Archive.md
@@ -41,7 +41,7 @@ Get a 30 day free trial of Freshbooks at [freshbooks.com/syntax](https://freshbo
 * **[38:00](#t=38:00)** Functions
 * **[39:27](#t=39:27)** Color names
 * **[42:02](#t=42:02)** Format of color
-* **[43:50](#t=43:50)** Most popular gardient on the web
+* **[43:50](#t=43:50)** Most popular gradient on the web
 * **[47:27](#t=47:27)** Sponsor: Freshbooks
 * **[47:57](#t=47:57)** We don't know the web
 * **[50:39](#t=50:39)** SIIIIICK ××× PIIIICKS ×××

--- a/shows/535 - Supper club.md
+++ b/shows/535 - Supper club.md
@@ -28,7 +28,7 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
 * [Web Assembly (WASM)](https://webassembly.org)
 * [Rustlings](https://github.com/rust-lang/rustlings)
 * **[19:46](#t=19:46)** Sponsor: Auth0
-* **[21:03](#t=21:03)** Which company will Vercel aquire next?
+* **[21:03](#t=21:03)** Which company will Vercel acquire next?
 * [Guillermo Rauch](https://twitter.com/rauchg)
 * [Akamai Acquires Linode](https://www.akamai.com/newsroom/press-release/akamai-to-acquire-linode)
 * **[27:12](#t=27:12)** Svelte Kit and Vercel

--- a/shows/537 - Hasty CSS.md
+++ b/shows/537 - Hasty CSS.md
@@ -45,8 +45,8 @@ LogRocket lets you replay what users do on your site, helping you reproduce bugs
 * **[42:28](#t=42:28)** Sass
 * **[43:20](#t=43:20)** Print styles
 * **[45:38](#t=45:38)** Sponsor: Sanity
-* **[46:38](#t=46:38)** Longhand properities
-* **[48:21](#t=48:21)** Non-existant properties
+* **[46:38](#t=46:38)** Longhand properties
+* **[48:21](#t=48:21)** Non-existent properties
 * **[52:06](#t=52:06)** SIIIIICK ××× PIIIICKS ×××
 
 ## ××× SIIIIICK ××× PIIIICKS ×××

--- a/shows/542 - Tasty Serverless.md
+++ b/shows/542 - Tasty Serverless.md
@@ -34,7 +34,7 @@ If you want to know what’s happening with your code, track errors and monitor 
 * [Netlify environmental variables](https://docs.netlify.com/configure-builds/environment-variables/)
 * **[14:37](#t=14:37)** Timeouts
 * **[15:47](#t=15:47)** Sass is expensive
-* **[17:26](#t=17:26)** Infastructure as code
+* **[17:26](#t=17:26)** Infrastructure as code
 * **[19:02](#t=19:02)** Search
 * [Algolia](https://www.algolia.com)
 

--- a/shows/555 - Tasty.md
+++ b/shows/555 - Tasty.md
@@ -41,7 +41,7 @@ Auth0 is the easiest way for developers to add authentication and secure their a
 * **[29:44](#t=29:44)** TypeScript
 * **[34:28](#t=34:28)** Sponsor: Sanity
 * **[35:07](#t=35:07)** Server comeback
-* **[36:21](#t=36:21)** Checkouts and payment processers
+* **[36:21](#t=36:21)** Checkouts and payment processors
 * [Lemon Squeezy](https://www.lemonsqueezy.com)
 * **[43:05](#t=43:05)** Sponsor: Auth0
 * **[44:18](#t=44:18)** Temporal API

--- a/shows/565 - Supper.md
+++ b/shows/565 - Supper.md
@@ -28,7 +28,7 @@ In this supper club episode of Syntax, Wes and Scott talk with Simen & Espen fro
 - **[04:04](#t=04:04)** What kinds of services use Sanity?
 - **[06:18](#t=06:18)** What is a content lake?
 - **[07:26](#t=07:26)** Enabling code access to Sanity Studio
-- **[13:12](#t=13:12)** Implenting Sanity into a React app
+- **[13:12](#t=13:12)** Implementing Sanity into a React app
 - **[14:49](#t=14:49)** What is GROQ?
 - **[21:04](#t=21:04)** Is GraphQL still the best way to query data?
 - **[25:32](#t=25:32)** Workflows in Sanity

--- a/shows/632 - Hasty Domains.md
+++ b/shows/632 - Hasty Domains.md
@@ -21,7 +21,7 @@ In this Hasty Treat, Scott and Wes talk about where you should register a domain
 * [Spaceship](https://www.spaceship.com/)
 * **[17:42](#t=17:42)** GoDaddy
 * [GoDaddy](https://www.godaddy.com/)
-* **[19:26](#t=19:26)** Gandhi
+* **[19:26](#t=19:26)** Gandi
 * [Gandi.net](https://www.gandi.net/en-CA)
 * **[21:16](#t=21:16)** Porkbun
 * [Porkbun](https://www.porkbun.com)

--- a/shows/632 - Hasty Domains.md
+++ b/shows/632 - Hasty Domains.md
@@ -21,7 +21,7 @@ In this Hasty Treat, Scott and Wes talk about where you should register a domain
 * [Spaceship](https://www.spaceship.com/)
 * **[17:42](#t=17:42)** GoDaddy
 * [GoDaddy](https://www.godaddy.com/)
-* **[19:26](#t=19:26)** Ghandi
+* **[19:26](#t=19:26)** Gandhi
 * [Gandi.net](https://www.gandi.net/en-CA)
 * **[21:16](#t=21:16)** Porkbun
 * [Porkbun](https://www.porkbun.com)

--- a/shows/639 - Tasty Stumpd.md
+++ b/shows/639 - Tasty Stumpd.md
@@ -25,7 +25,7 @@ In this episode of Syntax, Wes and Scott try to stump each other with questions 
 * **[13:20:19](#t=13:20:19)** What is a type erase in TypeScript?
 * **[14:21:23](#t=14:21:23)** In TypeScript which syntax can be used to define a user defined type guard?
 * **[16:02:12](#t=16:02:12)** What is a closure in JavaScript?
-* **[17:40:00](#t=17:40:00)** Which node.js module provides asynchronus file I/O?
+* **[17:40:00](#t=17:40:00)** Which node.js module provides asynchronous file I/O?
 * **[18:54:08](#t=18:54:08)** What does memory safety mean?
 * **[21:57:11](#t=21:57:11)** What does http2 introduce to improve speed?
 * **[23:58:05](#t=23:58:05)** What are strategies for optimizing HTML5 video?

--- a/shows/651 - Tasty Potluck.md
+++ b/shows/651 - Tasty Potluck.md
@@ -11,7 +11,7 @@ In this potluck episode of Syntax, Wes and Scott answer your questions about Typ
 
 * **[00:11](#t=00:11)** Welcome
 * **[03:11](#t=03:11)** The Sunday scaries
-* **[06:03](#t=06:03)** Is TypeSctipt just a bunch of fancy Duck Tape?
+* **[06:03](#t=06:03)** Is TypeScript just a bunch of fancy Duck Tape?
 * [Is TypeScript saving us?](https://stackblitz.com/edit/typescript-xddko7?file=index.ts,index.html)
 * **[12:29](#t=12:29)** How do you go years into programming without back pain?
 * [Hasty Treat - Stretching For Developers with Scott — Syntax Podcast 293](https://syntax.fm/show/293/hasty-treat-stretching-for-developers-with-scott)

--- a/shows/656 - Hasty Fetch.md
+++ b/shows/656 - Hasty Fetch.md
@@ -85,7 +85,7 @@ if(err) // ....
 
 * [await-to-js - npm](https://www.npmjs.com/package/await-to-js)
 * **[16:58](#t=16:58)** 7) Dev tools - Copy as fetch
-* **[17:54](#t=17:54)** 8) You can programatically create a Request, Response and Headers objects
+* **[17:54](#t=17:54)** 8) You can programmatically create a Request, Response and Headers objects
 
 ```
 const myRequest = new Request('https://traffic.libsyn.com/syntax/Syntax_-_641.mp3', {

--- a/shows/684 - tasty scary.md
+++ b/shows/684 - tasty scary.md
@@ -9,7 +9,7 @@ In this episode of Syntax, Wes and Scott relate even more spooky listener submit
 
 ## Show Notes
 
-- **[00:09](#t=00:09)** Velcome to Synax
+- **[00:09](#t=00:09)** Welcome to Syntax
 - **[01:09](#t=01:09)** Syntax Brought to you by Sentry
 - **[01:36](#t=01:36)** Stories are anonymous!
 - **[01:57](#t=01:57)** Crypto copy + paste

--- a/shows/687 - tasty.md
+++ b/shows/687 - tasty.md
@@ -41,7 +41,7 @@ In this potluck episode of Syntax, Wes and Scott answer your questions about hos
 - **[42:57](#t=42:57)** Subgrid and the :has selector usage
 - **[46:02](#t=46:02)** Is it okay to be a front end developer and not be as interested in CSS?
 - [Tool Academy (American TV series)](<https://en.wikipedia.org/wiki/Tool_Academy_(American_TV_series)>)
-- **[51:12](#t=51:12)** Could you explain what are workers, processes, jobs, tasks, and deamons?
+- **[51:12](#t=51:12)** Could you explain what are workers, processes, jobs, tasks, and daemons?
 - **[56:29](#t=56:29)** SIIIIICK ××× PIIIICKS ×××
 
 ## ××× SIIIIICK ××× PIIIICKS ×××

--- a/shows/714 - hasty.md
+++ b/shows/714 - hasty.md
@@ -14,7 +14,7 @@ CSS :has() is out in all browsers and Wes and Scott have got the top 10 reasons 
 * **[03:02](#t=03:02)** Overview of :has
 * **[07:09](#t=07:09)** The anywhere selector
 * **[09:41](#t=09:41)** Previous element
-* **[12:59](#t=12:59)** Layout targetting
+* **[12:59](#t=12:59)** Layout targeting
 * **[15:45](#t=15:45)** Form validation styling
 * **[17:51](#t=17:51)** All siblings
 * **[21:07](#t=21:07)** Quantity queries

--- a/shows/728 - AI Superpowers with Kevin Hou and Codeium.md
+++ b/shows/728 - AI Superpowers with Kevin Hou and Codeium.md
@@ -35,7 +35,7 @@ In this supper club, Scott and Wes welcome Kevin Hou, Head of Product Engineerin
 * **[32:09](#t=32:09)** Do AI models get worse over time? How does Codeium validate that it's not?
 * [Open AI Evals](https://github.com/openai/evals)
 * **[35:39](#t=35:39)** How is Codeium THAT fast?
-* **[36:49](#t=36:49)** What programming langauges does Codeium use?
+* **[36:49](#t=36:49)** What programming languages does Codeium use?
 * **[38:55](#t=38:55)** Codeium Playground.
 * [Codeium Playground](https://codeium.com/playground)
 * **[39:15](#t=39:15)** Caching as a performance improvement.

--- a/shows/741 - TypeScript Interview Questions - STUMP'd.md
+++ b/shows/741 - TypeScript Interview Questions - STUMP'd.md
@@ -25,7 +25,7 @@ Wes and Scott tackle TypeScript trivia, from combining string literal types to u
 * [Module .d.ts](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html)
 * **[16:25](#t=16:25)** Name one difference between a type and an interface.
 * [Types vs Interfaces](https://www.typescriptlang.org/play#example/types-vs-interfaces)
-* **[19:15](#t=19:15)** What is a tripple-slash directive and why would you use them?
+* **[19:15](#t=19:15)** What is a triple-slash directive and why would you use them?
 * [Tripple-Slash Directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html)
 * **[20:52](#t=20:52)** What is a TypeScript record and what is it used for?
 * [Utility Types](https://www.typescriptlang.org/docs/handbook/utility-types.html)

--- a/shows/763 - Web Scraping.md
+++ b/shows/763 - Web Scraping.md
@@ -36,7 +36,7 @@ Web scraping 101! Dive into the world of web scraping with Scott and Wes as they
 * **[36:26](#t=36:26)** File downloading.
 * **[38:20](#t=38:20)** Working with protected routes.
 * [Proxyman](https://proxyman.io/).
-* **[40:41](#t=40:41)** Programatically retrieve authentication keys because they are short-lived.
+* **[40:41](#t=40:41)** Programmatically retrieve authentication keys because they are short-lived.
 * [Fetch Cookie](https://www.npmjs.com/package/fetch-cookie).
 * **[43:20](#t=43:20)** Deal-breakers.
 * [Mechanical Turk](https://en.wikipedia.org/wiki/Mechanical_Turk).

--- a/shows/824 - Taylor Otwell.md
+++ b/shows/824 - Taylor Otwell.md
@@ -19,7 +19,7 @@ Wes and Scott talk with Taylor Otwell, the creator of Laravel. Taylor shares ins
 * **[00:00](#t=00:00)** Welcome to Syntax!
 * **[00:29](#t=00:29)** [Laracon](https://laracon.us/)
 * **[03:13](#t=03:13)** Laravel's inspiration and features
-  * [Intertia](https://inertiajs.com/)
+  * [Inertia](https://inertiajs.com/)
   * [Livewire](https://laravel-livewire.com/)
 * **[07:18](#t=07:18)** Why don't we have a "Laravel for JavaScript"?
 * **[09:02](#t=09:02)** What parts of Laravel came first?
@@ -27,7 +27,7 @@ Wes and Scott talk with Taylor Otwell, the creator of Laravel. Taylor shares ins
   * [Forge](https://forge.laravel.com/)
   * [Vapor](https://vapor.laravel.com/)
 * **[12:29](#t=12:29)** [Laravel Cloud](https://cloud.laravel.com/)
-* **[14:00](#t=14:00)** What parts of Laravel are Intertia and what parts are React?
+* **[14:00](#t=14:00)** What parts of Laravel are Inertia and what parts are React?
 * **[15:57](#t=15:57)** How many people are using Laravel?
 * **[16:59](#t=16:59)** Taylor's productivity and development philosophy
 * **[24:43](#t=24:43)** Brought to you by [Sentry.io](https://sentry.io)


### PR DESCRIPTION
Fixes #2200

## Summary

- Fixed 42 confirmed misspellings across 38 show note markdown files
- Detected with `cspell` using a custom config that whitelists tech terms, names, and sponsor words to avoid false positives
- No dialect differences — all genuine typos valid across EN-US/EN-GB/EN-CA

## Changes

Only `shows/*.md` files modified. No config or code changes.